### PR TITLE
Resolve keybinding conflict with joining lines

### DIFF
--- a/keymaps/symbols-view.cson
+++ b/keymaps/symbols-view.cson
@@ -1,6 +1,6 @@
 '.editor':
-  'meta-j': 'symbols-view:toggle-file-symbols'
+  'ctrl-j': 'symbols-view:toggle-file-symbols'
   'meta-.': 'symbols-view:go-to-declaration'
 
 'body':
-  'meta-J': 'symbols-view:toggle-project-symbols'
+  'ctrl-J': 'symbols-view:toggle-project-symbols'


### PR DESCRIPTION
Are people okay with swapping the keybindings on joining lines and launching the symbols view? (For sublime compatibility)

Part of atom/atom#1000
