### PR TITLE
Add support for jumping back from declaration.

### DIFF
--- a/keymaps/symbols-view.cson
+++ b/keymaps/symbols-view.cson
@@ -1,10 +1,12 @@
 '.platform-darwin .editor':
   'cmd-r': 'symbols-view:toggle-file-symbols'
   'cmd-alt-down': 'symbols-view:go-to-declaration'
+  'cmd-alt-up': 'symbols-view:return-from-declaration'
 
 '.platform-win32 .editor, .platform-linux .editor':
   'ctrl-r': 'symbols-view:toggle-file-symbols'
   'ctrl-alt-down': 'symbols-view:go-to-declaration'
+  'ctrl-alt-up': 'symbols-view:return-from-declaration'
 
 '.platform-darwin':
   'cmd-R': 'symbols-view:toggle-project-symbols'

--- a/lib/go-back-view.coffee
+++ b/lib/go-back-view.coffee
@@ -1,0 +1,13 @@
+SymbolsView = require './symbols-view'
+
+module.exports =
+class GoBackView extends SymbolsView
+  constructor: (@stack) ->
+    super
+
+  toggle: =>
+    return if @stack.length is 0
+
+    top = @stack.pop()
+    atom.workspaceView.open(top.file).done =>
+      @moveToPosition(top.position, false) if top.position

--- a/lib/go-to-view.coffee
+++ b/lib/go-to-view.coffee
@@ -5,6 +5,9 @@ TagReader = require './tag-reader'
 
 module.exports =
 class GoToView extends SymbolsView
+  constructor: (@stack) ->
+    super
+
   toggle: ->
     if @hasParent()
       @cancel()
@@ -41,3 +44,6 @@ class GoToView extends SymbolsView
             position: position
         @setItems(tags)
         @attach()
+
+   afterTagOpen: (previous) ->
+     @stack.push previous

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -3,6 +3,8 @@ module.exports =
     useEditorGrammarAsCtagsLanguage: true
 
   activate: ->
+    @stack = []
+
     atom.workspaceView.command 'symbols-view:toggle-file-symbols', =>
       @createFileView().toggle()
 
@@ -11,6 +13,9 @@ module.exports =
 
     atom.workspaceView.command 'symbols-view:go-to-declaration', =>
       @createGoToView().toggle()
+
+    atom.workspaceView.command 'symbols-view:return-from-declaration', =>
+      @createGoBackView().toggle()
 
   deactivate: ->
     if @fileView?
@@ -24,6 +29,10 @@ module.exports =
     if @goToView?
       @goToView.destroy()
       @goToView = null
+
+    if @goBackView?
+      @goBackView.destroy()
+      @goBackView = null
 
   createFileView: ->
     unless @fileView?
@@ -40,5 +49,11 @@ module.exports =
   createGoToView: ->
     unless @goToView?
       GoToView = require './go-to-view'
-      @goToView = new GoToView()
+      @goToView = new GoToView(@stack)
     @goToView
+
+  createGoBackView: ->
+    unless @goBackView?
+      GoBackView = require './go-back-view'
+      @goBackView = new GoBackView(@stack)
+    @goBackView;

--- a/lib/symbols-view.coffee
+++ b/lib/symbols-view.coffee
@@ -42,6 +42,11 @@ class SymbolsView extends SelectListView
       @openTag(tag)
 
   openTag: (tag) ->
+    editor = atom.workspace.getActiveEditor()
+    previous =
+      position: editor.getCursorBufferPosition()
+      file: editor.getUri()
+
     position = tag.position
     position = @getTagLine(tag) unless position
     if tag.file
@@ -50,12 +55,14 @@ class SymbolsView extends SelectListView
     else if position
       @moveToPosition(position)
 
-  moveToPosition: (position) ->
+    @afterTagOpen?(previous)
+
+  moveToPosition: (position, beginningOfLine=true) ->
     editorView = atom.workspaceView.getActiveView()
     if editor = editorView.getEditor?()
       editorView.scrollToBufferPosition(position, center: true)
       editor.setCursorBufferPosition(position)
-      editor.moveCursorToFirstCharacterOfLine()
+      editor.moveCursorToFirstCharacterOfLine() if beginningOfLine
 
   attach: ->
     @storeFocusedElement()

--- a/spec/symbols-view-spec.coffee
+++ b/spec/symbols-view-spec.coffee
@@ -217,6 +217,34 @@ describe "SymbolsView", ->
         expect(atom.workspaceView.getActivePaneItem().getPath()).toBe atom.project.resolve("tagged-duplicate.js")
         expect(atom.workspaceView.getActivePaneItem().getCursorBufferPosition()).toEqual [0,4]
 
+    describe "return from declaration", ->
+      it "doesn't do anything when no go-to have been triggered", ->
+        atom.workspaceView.openSync("tagged.js")
+        editor = atom.workspaceView.getActivePaneItem()
+        editor.setCursorBufferPosition([6,0])
+        atom.workspaceView.getActiveView().trigger 'symbols-view:return-from-declaration'
+        expect(editor.getCursorBufferPosition()).toEqual [6,0]
+
+      it "returns to previous row and column", ->
+        atom.workspaceView.openSync("tagged.js")
+        editor = atom.workspaceView.getActivePaneItem()
+        editor.setCursorBufferPosition([6,24])
+        spyOn(SymbolsView.prototype, "moveToPosition").andCallThrough()
+        atom.workspaceView.getActiveView().trigger 'symbols-view:go-to-declaration'
+
+        waitsFor ->
+          SymbolsView.prototype.moveToPosition.callCount == 1
+
+        runs ->
+          expect(editor.getCursorBufferPosition()).toEqual [2,0]
+          atom.workspaceView.getActiveView().trigger 'symbols-view:return-from-declaration'
+
+        waitsFor ->
+          SymbolsView.prototype.moveToPosition.callCount == 2
+
+        runs ->
+          expect(editor.getCursorBufferPosition()).toEqual [6,24]
+
     describe "when the tag is in a file that doesn't exist", ->
       it "doesn't display the tag", ->
         fs.removeSync(atom.project.resolve("tagged-duplicate.js"))


### PR DESCRIPTION
After a declaration have been jumped to, use the
'symbols-view:return-from-declaration' to go back
to where you were previously. All jumps are stored
so you can traverse deep, and step your way out.
