### PR TITLE
Add more context in symbol listing

### DIFF
--- a/lib/go-to-view.coffee
+++ b/lib/go-to-view.coffee
@@ -2,6 +2,7 @@ path = require 'path'
 Q = require 'q'
 SymbolsView = require './symbols-view'
 TagReader = require './tag-reader'
+{$$, Point, SelectListView} = require 'atom'
 
 module.exports =
 class GoToView extends SymbolsView
@@ -13,7 +14,7 @@ class GoToView extends SymbolsView
       @li class: 'two-lines', =>
         @div name, class: 'primary-line'
         if position
-          text = "Line #{position.row + 1}"
+          text = "#{file}:#{position.row + 1}"
         else
           text = path.basename(file)
         @div text, class: 'secondary-line'


### PR DESCRIPTION
I made some small changes so that when multiple symbols are found:
- The complete file path is listed, along with the line number
- When filtering the list, it filters on the file path, as opposed to just the name

The motivation is that the line number is not sufficient context for some of my projects. For example, the original would show (made up example):

```
----
Base
Line: 2
----
Base
Line: 3
----
```

After the change:

```
----
Base
active_record/base.rb:2
----
Base
active_support/base.rb:3
----

This is my first encounter with copfescript, so I just fixed the existing specs. I did not add a spec for the change in behavior in the filter key.

Thanks,
```
