### PR TITLE
getActiveEditor returns undefined if no window is open

### DIFF
--- a/lib/symbols-view.coffee
+++ b/lib/symbols-view.coffee
@@ -43,9 +43,12 @@ class SymbolsView extends SelectListView
 
   openTag: (tag) ->
     editor = atom.workspace.getActiveEditor()
-    previous =
-      position: editor.getCursorBufferPosition()
-      file: editor.getUri()
+    if editor
+      previous =
+        position: editor.getCursorBufferPosition()
+        file: editor.getUri()
+
+      @afterTagOpen?(previous)
 
     position = tag.position
     position = @getTagLine(tag) unless position
@@ -54,8 +57,6 @@ class SymbolsView extends SelectListView
         @moveToPosition(position) if position
     else if position
       @moveToPosition(position)
-
-    @afterTagOpen?(previous)
 
   moveToPosition: (position, beginningOfLine=true) ->
     editorView = atom.workspaceView.getActiveView()


### PR DESCRIPTION
- lib/symbols-view.coffee:45 attempts to grab the current editor
  and then feed the cursorBufferPosition into var previous.
  If there is no current editor open, an undefined error is thrown
  on getCursorBufferPosition when trying to assign var previous.
- Add an if statement to check the editor before calling
  getCursorBufferPosition() on an undefined object.
  - Resolves #29.
