### PR TITLE
Add jumping back for file-view and project-view

### DIFF
--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -3,6 +3,8 @@ TagGenerator = require './tag-generator'
 
 module.exports =
 class FileView extends SymbolsView
+  constructor: (@stack) ->
+    super
   initialize: ->
     super
 
@@ -47,3 +49,6 @@ class FileView extends SymbolsView
       @cachedTags[filePath] = tags
       @maxItem = Infinity
       @setItems(tags)
+
+  afterTagOpen: (previous) ->
+    @stack.push previous

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -37,13 +37,13 @@ module.exports =
   createFileView: ->
     unless @fileView?
       FileView  = require './file-view'
-      @fileView = new FileView()
+      @fileView = new FileView(@stack)
     @fileView
 
   createProjectView:  ->
     unless @projectView?
       ProjectView  = require './project-view'
-      @projectView = new ProjectView()
+      @projectView = new ProjectView(@stack)
     @projectView
 
   createGoToView: ->

--- a/lib/project-view.coffee
+++ b/lib/project-view.coffee
@@ -5,6 +5,8 @@ TagReader = require './tag-reader'
 
 module.exports =
 class ProjectView extends SymbolsView
+  constructor: (@stack) ->
+    super
   initialize: ->
     super
     @reloadTags = true
@@ -68,3 +70,6 @@ class ProjectView extends SymbolsView
 
   unwatchTagsFile: ->
     @tagsFile?.off()
+
+  afterTagOpen: (previous) ->
+    @stack.push previous


### PR DESCRIPTION
Current jumping back only support go-to-declaration(cmd-option-down).
Now it can be used when jumping by file-view(cmd-r) or
project-view(cmd-shift-r)
