### PR TITLE
Add support for Ruby bang and question methods

### DIFF
--- a/lib/tag-reader.coffee
+++ b/lib/tag-reader.coffee
@@ -16,11 +16,13 @@ module.exports =
     return tagsFile if fs.isFileSync(tagsFile)
 
   find: (editor, callback) ->
-    word = editor.getTextInRange(editor.getCursor().getCurrentWordBufferRange())
+    range = editor.getCursor().getCurrentWordBufferRange()
+    symbol = getSymbolFromRange(editor, range)
+
     tagsFile = @getTagsFile()
 
-    if word?.length > 0 and tagsFile
-      ctags.findTags(tagsFile, word, callback)
+    if symbol?.length > 0 and tagsFile
+      ctags.findTags(tagsFile, symbol, callback)
     else
       process.nextTick -> callback(null, [])
 
@@ -29,3 +31,15 @@ module.exports =
     task = Task.once handlerPath, atom.project.getPath(), -> callback(projectTags)
     task.on 'tags', (paths) -> projectTags.push(paths...)
     task
+
+getSymbolFromRange = (editor, range) ->
+  word = editor.getTextInRange(range)
+  charAfterWord = getCharAfterWord(editor, range)
+
+  if charAfterWord == "?" or charAfterWord == "!"
+    return word + charAfterWord
+  else
+    return word
+
+getCharAfterWord = (editor, range) ->
+  return editor.getTextInRange([[range.end.row, range.end.column], [range.end.row, range.end.column + 1]])


### PR DESCRIPTION
- The ::find method of tag-reader.coffee uses getCurrentWordBufferRange()
  to pull in the current word to pull in the current tag. Passing in a
  custom regexp to getCurrentWordBufferRange() determines what constitutes
  a word.
- By slightly modifying the default regexp used (from Cursor::wordRegExp),
  we can pull in 'words' that have either a ? or ! at the end of the method,
  which is common in the Ruby programming language.
- This resolves issue #32.
