### PR TITLE
Extended Rules to support Modern Perl

### DIFF
--- a/lib/.ctags
+++ b/lib/.ctags
@@ -65,3 +65,19 @@
 --regex-Go=/func([ \t]+\([^)]+\))?[ \t]+([a-zA-Z0-9_]+)/\2/f,func/
 --regex-Go=/var[ \t]+([a-zA-Z_][a-zA-Z0-9_]+)/\1/v,var/
 --regex-Go=/type[ \t]+([a-zA-Z_][a-zA-Z0-9_]+)/\1/t,type/
+
+--langmap=perl:+.pod
+--regex-perl=/with\s+([^;]+)\s*?;/\1/w,role,roles/
+--regex-perl=/extends\s+['"]([^'"]+)['"]\s*?;/\1/e,extends/
+--regex-perl=/use\s+base\s+['"]([^'"]+)['"]\s*?;/\1/e,extends/
+--regex-perl=/use\s+parent\s+['"]([^'"]+)['"]\s*?;/\1/e,extends/
+--regex-perl=/Mojo::Base\s+['"]([^'"]+)['"]\s*?;/\1/e,extends/
+--regex-perl=/^\s*?use\s+([^;]+)\s*?;/\1/u,use,uses/
+--regex-perl=/^\s*?require\s+((\w|\:)+)/\1/r,require,requires/
+--regex-perl=/^\s*?has\s+['"]?(\w+)['"]?/\1/a,attribute,attributes/
+--regex-perl=/^\s*?\*(\w+)\s*?=/\1/a,alias,aliases/
+--regex-perl=/->helper\(\s?['"]?(\w+)['"]?/\1/h,helper,helpers/
+--regex-perl=/^\s*?our\s*?[\$@%](\w+)/\1/o,our,ours/
+--regex-perl=/^\=head1\s+(.+)/\1/p,pod,Plain Old Documentation/
+--regex-perl=/^\=head2\s+(.+)/-- \1/p,pod,Plain Old Documentation/
+--regex-perl=/^\=head[3-5]\s+(.+)/---- \1/p,pod,Plain Old Documentation/


### PR DESCRIPTION
Extended Rules to support Modern Perl in Exuberant Ctags
Here are some additional regular expressions to support more Perl symbols. 
