### PR TITLE
support jsx file using javascript rule

### DIFF
--- a/lib/tag-generator.coffee
+++ b/lib/tag-generator.coffee
@@ -29,6 +29,8 @@ class TagGenerator
       when 'source.go'       then 'Go'
       when 'source.java'     then 'Java'
       when 'source.js'       then 'JavaScript'
+      when 'source.js.jsx'   then 'JavaScript'
+      when 'source.jsx'      then 'JavaScript'
       when 'source.json'     then 'Json'
       when 'source.makefile' then 'Make'
       when 'source.objc'     then 'C'


### PR DESCRIPTION
I add two source type for jsx file because some famous plugin using ".js.jsx" as source type
