### PR TITLE
Bugfix: .tags doesn't work as filename

### DIFF
--- a/lib/load-tags-handler.coffee
+++ b/lib/load-tags-handler.coffee
@@ -5,6 +5,9 @@ fs = require 'fs-plus'
 getTagsFile = (directoryPath) ->
   tagsFile = path.join(directoryPath, "tags")
   return tagsFile if fs.isFileSync(tagsFile)
+  
+  tagsFile = path.join(directoryPath, ".tags")
+  return tagsFile if fs.isFileSync(tagsFile)
 
   tagsFile = path.join(directoryPath, "TAGS")
   return tagsFile if fs.isFileSync(tagsFile)


### PR DESCRIPTION
The README says .tags is supported - but that's incorrect. This PR fixes that.