### PR TITLE
Fix issue #87, symbols generator is blocked

### DIFF
--- a/lib/tag-generator.coffee
+++ b/lib/tag-generator.coffee
@@ -59,10 +59,12 @@ class TagGenerator
       for line in lines.split('\n')
         if tag = @parseTagLine(line)
           tags[tag.position.row] ?= tag
+    stderr = (lines) ->
+      return
     exit = ->
       tags = (tag for row, tag of tags)
       deferred.resolve(tags)
 
-    new BufferedProcess({command, args, stdout, exit})
+    new BufferedProcess({command, args, stdout, stderr, exit})
 
     deferred.promise


### PR DESCRIPTION
I guess it's because sometimes `ctags` produce too much warings in `stderr`, if we don't handle it, the process will be blocked.