### PR TITLE
Remove Go to Declaration from mini editor context menu

### DIFF
--- a/menus/symbols-view.cson
+++ b/menus/symbols-view.cson
@@ -12,6 +12,6 @@
 ]
 
 'context-menu':
-  'atom-text-editor': [
+  'atom-text-editor:not([mini])': [
     { 'label': 'Go to Declaration', 'command': 'symbols-view:go-to-declaration' }
   ]


### PR DESCRIPTION
Part of atom/settings-view#354

This removes Go to Declaration from mini editors' context menus - if this is a bit too far-reaching I can limit it to mini editors in panes without file paths, but the current behavior is confusing.