### PR TITLE
Add match highlighting for symbols

### DIFF
--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -31,28 +31,8 @@ class FileView extends SymbolsView
     matches = match(name, filterQuery)
 
     $$ ->
-      highlighter = (name, matches, offsetIndex) =>
-        lastIndex = 0
-        matchedChars = [] # Build up a set of matched chars to be more semantic
-
-        for matchIndex in matches
-          matchIndex -= offsetIndex
-          continue if matchIndex < 0 # If marking up the basename, omit name matches
-          unmatched = name.substring(lastIndex, matchIndex)
-          if unmatched
-            @span matchedChars.join(''), class: 'character-match' if matchedChars.length
-            matchedChars = []
-            @text unmatched
-          matchedChars.push(name[matchIndex])
-          lastIndex = matchIndex + 1
-
-        @span matchedChars.join(''), class: 'character-match' if matchedChars.length
-
-        # Remaining characters are plain text
-        @text name.substring(lastIndex)
-
       @li class: 'two-lines', =>
-        @div class: 'primary-line', -> highlighter(name, matches, 0)
+        @div class: 'primary-line', => FileView.highlightMatches(this, name, matches)
         @div "Line #{position.row + 1}", class: 'secondary-line'
 
   toggle: ->

--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -27,8 +27,7 @@ class FileView extends SymbolsView
 
   viewForItem: ({position, name}) ->
     # Style matched characters in search results
-    filterQuery = @getFilterQuery()
-    matches = match(name, filterQuery)
+    matches = match(name, @getFilterQuery())
 
     $$ ->
       @li class: 'two-lines', =>

--- a/lib/symbols-view.coffee
+++ b/lib/symbols-view.coffee
@@ -2,6 +2,7 @@ path = require 'path'
 {Point} = require 'atom'
 {$$, SelectListView} = require 'atom-space-pen-views'
 fs = require 'fs-plus'
+{match} = require 'fuzzaldrin'
 
 module.exports =
 class SymbolsView extends SelectListView

--- a/lib/symbols-view.coffee
+++ b/lib/symbols-view.coffee
@@ -39,8 +39,7 @@ class SymbolsView extends SelectListView
 
   viewForItem: ({position, name, file, directory}) ->
     # Style matched characters in search results
-    filterQuery = @getFilterQuery()
-    matches = match(name, filterQuery)
+    matches = match(name, @getFilterQuery())
 
     if atom.project.getPaths().length > 1
       file = path.join(path.basename(directory), file)

--- a/lib/symbols-view.coffee
+++ b/lib/symbols-view.coffee
@@ -9,6 +9,26 @@ class SymbolsView extends SelectListView
   @activate: ->
     new SymbolsView
 
+  @highlightMatches: (context, name, matches, offsetIndex=0) ->
+    lastIndex = 0
+    matchedChars = [] # Build up a set of matched chars to be more semantic
+
+    for matchIndex in matches
+      matchIndex -= offsetIndex
+      continue if matchIndex < 0 # If marking up the basename, omit name matches
+      unmatched = name.substring(lastIndex, matchIndex)
+      if unmatched
+        context.span matchedChars.join(''), class: 'character-match' if matchedChars.length
+        matchedChars = []
+        context.text unmatched
+      matchedChars.push(name[matchIndex])
+      lastIndex = matchIndex + 1
+
+    context.span matchedChars.join(''), class: 'character-match' if matchedChars.length
+
+    # Remaining characters are plain text
+    context.text name.substring(lastIndex)
+
   initialize: (@stack) ->
     super
     @panel = atom.workspace.addModalPanel(item: this, visible: false)
@@ -29,31 +49,11 @@ class SymbolsView extends SelectListView
       file = path.join(path.basename(directory), file)
 
     $$ ->
-      highlighter = (name, matches, offsetIndex) =>
-        lastIndex = 0
-        matchedChars = [] # Build up a set of matched chars to be more semantic
-
-        for matchIndex in matches
-          matchIndex -= offsetIndex
-          continue if matchIndex < 0 # If marking up the basename, omit name matches
-          unmatched = name.substring(lastIndex, matchIndex)
-          if unmatched
-            @span matchedChars.join(''), class: 'character-match' if matchedChars.length
-            matchedChars = []
-            @text unmatched
-          matchedChars.push(name[matchIndex])
-          lastIndex = matchIndex + 1
-
-        @span matchedChars.join(''), class: 'character-match' if matchedChars.length
-
-        # Remaining characters are plain text
-        @text name.substring(lastIndex)
-
       @li class: 'two-lines', =>
         if position?
           @div "#{name}:#{position.row + 1}", class: 'primary-line'
         else
-          @div class: 'primary-line', -> highlighter(name, matches, 0)
+          @div class: 'primary-line', => SymbolsView.highlightMatches(this, name, matches)
         @div file, class: 'secondary-line'
 
   getEmptyMessage: (itemCount) ->

--- a/lib/symbols-view.coffee
+++ b/lib/symbols-view.coffee
@@ -6,9 +6,6 @@ fs = require 'fs-plus'
 
 module.exports =
 class SymbolsView extends SelectListView
-  @activate: ->
-    new SymbolsView
-
   @highlightMatches: (context, name, matches, offsetIndex=0) ->
     lastIndex = 0
     matchedChars = [] # Build up a set of matched chars to be more semantic

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "atom-space-pen-views": "^2.0.0",
     "ctags": "^2.0.0",
     "fs-plus": "^2.0.0",
+    "fuzzaldrin": "^2.1.0",
     "humanize-plus": "1.4.2",
     "pathwatcher": "^4.3",
     "q": "^1.1.2",

--- a/spec/symbols-view-spec.coffee
+++ b/spec/symbols-view-spec.coffee
@@ -478,3 +478,76 @@ describe "SymbolsView", ->
         expect($(getWorkspaceView()).find('.symbols-view')).toExist()
         expect(symbolsView.list.children('li:first').find('.primary-line')).toHaveText 'test'
         expect(symbolsView.list.children('li:first').find('.secondary-line')).toHaveText 'Line 1'
+
+  describe "match highlighting", ->
+    beforeEach ->
+      waitsForPromise ->
+        atom.workspace.open(directory.resolve('sample.js'))
+
+    it "highlights an exact match", ->
+      runs ->
+        atom.commands.dispatch(getEditorView(), "symbols-view:toggle-file-symbols")
+
+      waitsForPromise ->
+        activationPromise
+
+      runs ->
+        symbolsView = $(getWorkspaceView()).find('.symbols-view').view()
+
+      waitsFor ->
+        symbolsView.list.children('li').length > 0
+
+      runs ->
+        symbolsView.filterEditorView.getModel().setText('quicksort')
+        expect(symbolsView.filterEditorView.getModel().getText()).toBe 'quicksort'
+        symbolsView.populateList()
+        resultView = symbolsView.getSelectedItemView()
+
+        matches = resultView.find('.character-match')
+        expect(matches.length).toBe 1
+        expect(matches.last().text()).toBe 'quicksort'
+
+    it "highlights a partial match", ->
+      runs ->
+        atom.commands.dispatch(getEditorView(), "symbols-view:toggle-file-symbols")
+
+      waitsForPromise ->
+        activationPromise
+
+      runs ->
+        symbolsView = $(getWorkspaceView()).find('.symbols-view').view()
+
+      waitsFor ->
+        symbolsView.list.children('li').length > 0
+
+      runs ->
+        symbolsView.filterEditorView.getModel().setText('quick')
+        symbolsView.populateList()
+        resultView = symbolsView.getSelectedItemView()
+
+        matches = resultView.find('.character-match')
+        expect(matches.length).toBe 1
+        expect(matches.last().text()).toBe 'quick'
+
+    it "highlights multiple matches in the symbol name", ->
+      runs ->
+        atom.commands.dispatch(getEditorView(), "symbols-view:toggle-file-symbols")
+
+      waitsForPromise ->
+        activationPromise
+
+      runs ->
+        symbolsView = $(getWorkspaceView()).find('.symbols-view').view()
+
+      waitsFor ->
+        symbolsView.list.children('li').length > 0
+
+      runs ->
+        symbolsView.filterEditorView.getModel().setText('quicort')
+        symbolsView.populateList()
+        resultView = symbolsView.getSelectedItemView()
+
+        matches = resultView.find('.character-match')
+        expect(matches.length).toBe 2
+        expect(matches.first().text()).toBe 'quic'
+        expect(matches.last().text()).toBe 'ort'

--- a/styles/symbols-view.less
+++ b/styles/symbols-view.less
@@ -1,0 +1,7 @@
+@import "ui-variables";
+
+// Highlight matched text
+.symbols-view .list-group .character-match {
+  color: @text-color-highlight;
+  font-weight: bold;
+}


### PR DESCRIPTION
This adds match highlighting for symbols in the Symbols View:

![screenshot 2015-05-14 14 17 45](https://cloud.githubusercontent.com/assets/823545/7638588/0287b078-fa44-11e4-9f3d-59b8ee30b99e.png)

(Thanks @philschatz for the implementation in fuzzy-finder!)

/cc @kevinsawicki 