### PR TITLE
Add support for quickly jumping to symbol positions for FileView

### DIFF
--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -34,16 +34,39 @@ class FileView extends SymbolsView
         @div class: 'primary-line', => FileView.highlightMatches(this, name, matches)
         @div "Line #{position.row + 1}", class: 'secondary-line'
 
+  selectItemView: ->
+    super
+    item = @getSelectedItem()
+    @openTag(item) if item?
+
+  cancelled: ->
+    super
+    if @initialState? and editor = @getEditor()
+      @deserializeEditorState(editor, @initialState)
+
   toggle: ->
     if @panel.isVisible()
       @cancel()
     else if filePath = @getPath()
+      if editor = @getEditor()
+        @initialState = @serializeEditorState(editor)
       @populate(filePath)
       @attach()
 
-  getPath: -> atom.workspace.getActiveTextEditor()?.getPath()
+  serializeEditorState: (editor) ->
+    bufferRanges: editor.getSelectedBufferRanges()
+    scrollTop: editor.getScrollTop()
 
-  getScopeName: -> atom.workspace.getActiveTextEditor()?.getGrammar()?.scopeName
+  deserializeEditorState: (editor, state) ->
+    {bufferRanges, scrollTop} = state
+    editor.setSelectedBufferRanges(bufferRanges)
+    editor.setScrollTop(scrollTop)
+
+  getEditor: -> atom.workspace.getActiveTextEditor()
+
+  getPath: -> @getEditor()?.getPath()
+
+  getScopeName: -> @getEditor()?.getGrammar()?.scopeName
 
   populate: (filePath) ->
     @list.empty()

--- a/lib/symbols-view.coffee
+++ b/lib/symbols-view.coffee
@@ -80,7 +80,7 @@ class SymbolsView extends SelectListView
     if tag.file
       atom.workspace.open(path.join(tag.directory, tag.file)).done =>
         @moveToPosition(position) if position
-    else if position
+    else if position and not (previous.position.isEqual(position))
       @moveToPosition(position)
 
     @stack.push(previous)

--- a/spec/symbols-view-spec.coffee
+++ b/spec/symbols-view-spec.coffee
@@ -576,7 +576,7 @@ describe "SymbolsView", ->
         expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [1,2]
 
     it "restores previous editor state on cancel", ->
-      bufferRanges = [{"start":{"row":0,"column":0},"end":{"row":0,"column":3}}]
+      bufferRanges = [{"start": {"row": 0, "column": 0}, "end": {"row": 0, "column": 3}}]
       runs ->
         atom.workspace.getActiveTextEditor().setSelectedBufferRanges bufferRanges
         atom.commands.dispatch(getEditorView(), "symbols-view:toggle-file-symbols")

--- a/spec/symbols-view-spec.coffee
+++ b/spec/symbols-view-spec.coffee
@@ -551,3 +551,47 @@ describe "SymbolsView", ->
         expect(matches.length).toBe 2
         expect(matches.first().text()).toBe 'quic'
         expect(matches.last().text()).toBe 'ort'
+
+  describe "quickjump to symbol", ->
+    beforeEach ->
+      waitsForPromise ->
+        atom.workspace.open(directory.resolve('sample.js'))
+
+    it "jumps to the selected function", ->
+      runs ->
+        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [0,0]
+        atom.commands.dispatch(getEditorView(), "symbols-view:toggle-file-symbols")
+
+      waitsForPromise ->
+        activationPromise
+
+      runs ->
+        symbolsView = $(getWorkspaceView()).find('.symbols-view').view()
+
+      waitsFor ->
+        symbolsView.list.children('li').length > 0
+
+      runs ->
+        symbolsView.selectNextItemView()
+        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [1,2]
+
+    it "restores previous editor state on cancel", ->
+      bufferRanges = [{"start":{"row":0,"column":0},"end":{"row":0,"column":3}}]
+      runs ->
+        atom.workspace.getActiveTextEditor().setSelectedBufferRanges bufferRanges
+        atom.commands.dispatch(getEditorView(), "symbols-view:toggle-file-symbols")
+
+      waitsForPromise ->
+        activationPromise
+
+      runs ->
+        symbolsView = $(getWorkspaceView()).find('.symbols-view').view()
+
+      waitsFor ->
+        symbolsView.list.children('li').length > 0
+
+      runs ->
+        symbolsView.selectNextItemView()
+        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [1,2]
+        symbolsView.cancel()
+        expect(atom.workspace.getActiveTextEditor().getSelectedBufferRanges()).toEqual bufferRanges


### PR DESCRIPTION
![symbols-view](https://cloud.githubusercontent.com/assets/170500/6097453/6bbd5cd0-afbe-11e4-93ea-a7eef460efb9.gif)

- only applies to FileView
- takes care of restoring initial editor state if view does not get confirmed
- fixes #19