### PR TITLE
Make quickJumpToSymbol optional

### DIFF
--- a/lib/file-view.coffee
+++ b/lib/file-view.coffee
@@ -38,8 +38,9 @@ class FileView extends SymbolsView
 
   selectItemView: ->
     super
-    item = @getSelectedItem()
-    @openTag(item) if item?
+    if atom.config.get('symbols-view.quickJumpToFileSymbol')
+      item = @getSelectedItem()
+      @openTag(item) if item?
 
   cancelled: ->
     super
@@ -51,7 +52,7 @@ class FileView extends SymbolsView
     if @panel.isVisible()
       @cancel()
     else if filePath = @getPath()
-      if editor = @getEditor()
+      if atom.config.get('symbols-view.quickJumpToFileSymbol') and editor = @getEditor()
         @initialState = @serializeEditorState(editor)
       @populate(filePath)
       @attach()

--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
       "default": true,
       "type": "boolean",
       "description": "Force ctags to use the name of the current file's language in Atom when generating tags. By default, ctags automatically selects the language of a source file, ignoring those files whose language cannot be determined. This option forces the specified language to be used instead of automatically selecting the language based upon its extension."
+    },
+    "quickJumpToFileSymbol": {
+      "default": true,
+      "type": "boolean",
+      "description": "Automatically visit selected file-symbols"
     }
   },
   "repository": "https://github.com/atom/symbols-view",

--- a/spec/symbols-view-spec.coffee
+++ b/spec/symbols-view-spec.coffee
@@ -605,3 +605,28 @@ describe "SymbolsView", ->
         expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [1, 2]
         symbolsView.cancel()
         expect(atom.workspace.getActiveTextEditor().getSelectedBufferRanges()).toEqual bufferRanges
+
+  describe "when quickJumpToSymbol is set to false", ->
+    beforeEach ->
+      atom.config.set('symbols-view.quickJumpToFileSymbol', false)
+      waitsForPromise ->
+        atom.workspace.open(directory.resolve('sample.js'))
+
+    it "won't jumps to the selected function", ->
+
+      runs ->
+        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [0, 0]
+        atom.commands.dispatch(getEditorView(), "symbols-view:toggle-file-symbols")
+
+      waitsForPromise ->
+        activationPromise
+
+      runs ->
+        symbolsView = $(getWorkspaceView()).find('.symbols-view').view()
+
+      waitsFor ->
+        symbolsView.list.children('li').length > 0
+
+      runs ->
+        symbolsView.selectNextItemView()
+        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [0, 0]


### PR DESCRIPTION
I want quick jump is optional.
Its not only because of issue I reported in #105.
Its because I don’t like frequent screen update.
Maybe there are other people like me.
