### PR TITLE
Add simple support for Cap'n Proto (capnp) schema language

### DIFF
--- a/lib/ctags-config
+++ b/lib/ctags-config
@@ -67,6 +67,12 @@
 --regex-Go=/var[ \t]+([a-zA-Z_][a-zA-Z0-9_]*)/\1/v,var/
 --regex-Go=/type[ \t]+([a-zA-Z_][a-zA-Z0-9_]*)/\1/t,type/
 
+--langdef=Capnp
+--langmap=Capnp:.capnp
+--regex-Capnp=/struct[ \t]+([A-Za-z]+)/\1/s,struct/
+--regex-Capnp=/enum[ \t]+([A-Za-z]+)/\1/e,enum/
+--regex-Capnp=/using[ \t]+([A-Za-z]+)[ \t]+=[ \t]+import/\1/u,using/
+
 --langmap=perl:+.pod
 --regex-perl=/with[ \t]+([^;]+)[ \t]*?;/\1/w,role,roles/
 --regex-perl=/extends[ \t]+['"]([^'"]+)['"][ \t]*?;/\1/e,extends/

--- a/lib/ctags-config
+++ b/lib/ctags-config
@@ -72,6 +72,7 @@
 --regex-Capnp=/struct[ \t]+([A-Za-z]+)/\1/s,struct/
 --regex-Capnp=/enum[ \t]+([A-Za-z]+)/\1/e,enum/
 --regex-Capnp=/using[ \t]+([A-Za-z]+)[ \t]+=[ \t]+import/\1/u,using/
+--regex-Capnp=/const[ \t]+([A-Za-z]+)/\1/c,const/
 
 --langmap=perl:+.pod
 --regex-perl=/with[ \t]+([^;]+)[ \t]*?;/\1/w,role,roles/

--- a/lib/tag-generator.coffee
+++ b/lib/tag-generator.coffee
@@ -29,6 +29,7 @@ class TagGenerator
       when 'source.c'        then 'C'
       when 'source.cpp'      then 'C++'
       when 'source.clojure'  then 'Lisp'
+      when 'source.capnp'    then 'Capnp'
       when 'source.coffee'   then 'CoffeeScript'
       when 'source.css'      then 'Css'
       when 'source.css.less' then 'Css'
@@ -52,6 +53,7 @@ class TagGenerator
       when 'source.yaml'     then 'Yaml'
       when 'text.html'       then 'Html'
       when 'text.html.php'   then 'Php'
+    console.log @scopeName
 
   generate: ->
     deferred = Q.defer()
@@ -63,11 +65,13 @@ class TagGenerator
 
     if atom.config.get('symbols-view.useEditorGrammarAsCtagsLanguage')
       if language = @getLanguage()
+        console.log language
         args.push("--language-force=#{language}")
 
     args.push('-nf', '-', @path)
 
     stdout = (lines) =>
+      console.log lines
       for line in lines.split('\n')
         if tag = @parseTagLine(line)
           tags[tag.position.row] ?= tag

--- a/lib/tag-generator.coffee
+++ b/lib/tag-generator.coffee
@@ -53,7 +53,6 @@ class TagGenerator
       when 'source.yaml'     then 'Yaml'
       when 'text.html'       then 'Html'
       when 'text.html.php'   then 'Php'
-    console.log @scopeName
 
   generate: ->
     deferred = Q.defer()
@@ -65,13 +64,11 @@ class TagGenerator
 
     if atom.config.get('symbols-view.useEditorGrammarAsCtagsLanguage')
       if language = @getLanguage()
-        console.log language
         args.push("--language-force=#{language}")
 
     args.push('-nf', '-', @path)
 
     stdout = (lines) =>
-      console.log lines
       for line in lines.split('\n')
         if tag = @parseTagLine(line)
           tags[tag.position.row] ?= tag


### PR DESCRIPTION
[Cap'n Proto](https://capnproto.org/language.html) is binary format RPC protocol, which has own schema language to support cross platform, cross language. 

I add simple support for Cap'n Proto schema language. It supports struct enum using const.
