### PR TITLE
Add description for config setting

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -3,6 +3,7 @@ module.exports =
     useEditorGrammarAsCtagsLanguage:
       default: true
       type: 'boolean'
+      description: 'Force ctags to use the name of the current file\'s language in Atom when generating tags. By default, ctags automatically selects the language of a source file, ignoring those files whose language cannot be determined. This option forces the specified language to be used instead of automatically selecting the language based upon its extension.'
 
   activate: ->
     @stack = []


### PR DESCRIPTION
As a followup to atom/atom#9096, this adds descriptions for config settings in this package.