### PR TITLE
More resilient spec

### DIFF
--- a/spec/symbols-view-spec.coffee
+++ b/spec/symbols-view-spec.coffee
@@ -367,7 +367,7 @@ describe "SymbolsView", ->
         symbolsView = $(getWorkspaceView()).find('.symbols-view').view()
 
       waitsFor "loading", ->
-        symbolsView.setLoading.callCount is 1
+        symbolsView.setLoading.callCount > 1
 
       waitsFor ->
         symbolsView.list.children('li').length > 0
@@ -472,6 +472,7 @@ describe "SymbolsView", ->
       runs ->
         atom.commands.dispatch(getEditorView(), "symbols-view:toggle-file-symbols")
         atom.workspace.getActiveTextEditor().setGrammar(atom.grammars.grammarForScopeName('source.js'))
+        symbolsView.setLoading.reset()
         atom.commands.dispatch(getEditorView(), "symbols-view:toggle-file-symbols")
         symbolsView = $(getWorkspaceView()).find('.symbols-view').view()
 

--- a/spec/symbols-view-spec.coffee
+++ b/spec/symbols-view-spec.coffee
@@ -12,6 +12,8 @@ describe "SymbolsView", ->
   getEditorView = -> atom.views.getView(atom.workspace.getActiveTextEditor())
 
   beforeEach ->
+    spyOn(SymbolsView::, "setLoading").andCallThrough()
+
     atom.project.setPaths([
       temp.mkdirSync("other-dir-")
       temp.mkdirSync('atom-symbols-view-')
@@ -37,7 +39,9 @@ describe "SymbolsView", ->
 
       runs ->
         symbolsView = $(getWorkspaceView()).find('.symbols-view').view()
-        expect(symbolsView.loading).toBeVisible()
+
+      waitsFor "loading", ->
+        symbolsView.setLoading.callCount > 1
 
       waitsFor ->
         symbolsView.list.children('li').length > 0
@@ -361,7 +365,9 @@ describe "SymbolsView", ->
 
       runs ->
         symbolsView = $(getWorkspaceView()).find('.symbols-view').view()
-        expect(symbolsView.loading).toBeVisible()
+
+      waitsFor "loading", ->
+        symbolsView.setLoading.callCount is 1
 
       waitsFor ->
         symbolsView.list.children('li').length > 0
@@ -468,7 +474,9 @@ describe "SymbolsView", ->
         atom.workspace.getActiveTextEditor().setGrammar(atom.grammars.grammarForScopeName('source.js'))
         atom.commands.dispatch(getEditorView(), "symbols-view:toggle-file-symbols")
         symbolsView = $(getWorkspaceView()).find('.symbols-view').view()
-        expect(symbolsView.loading).toBeVisible()
+
+      waitsFor "loading", ->
+        symbolsView.setLoading.callCount > 1
 
       waitsFor ->
         symbolsView.list.children('li').length is 1


### PR DESCRIPTION
Closes #128 

I have seen these specs failing a bunch of times on atom/atom, and they almost always seem false positives. This PR spies upon `SymbolsView::setLoading` instead of checking for `::loading` visibility: the problem with using `toBeVisible()` is that, whenever loading is faster than our test code, the assertion will get executed **after** loading has been already hidden, thus making the tests fail.

I'll give them a couple of spins on Travis to see whether or not this fixes it. If after 5 times it's always green, I'll go on and :ship: this.