### PR TITLE
When scrolling to symbol, center it in the buffer

### DIFF
--- a/lib/symbols-view.js
+++ b/lib/symbols-view.js
@@ -174,11 +174,11 @@ export default class SymbolsView {
       beginningOfLine = true;
     }
     if (editor) {
-      editor.scrollToBufferPosition(position, {center: true});
-      editor.setCursorBufferPosition(position);
+      editor.setCursorBufferPosition(position, {autoscroll: false});
       if (beginningOfLine) {
         editor.moveToFirstCharacterOfLine();
       }
+      editor.scrollToCursorPosition({center: true});
     }
   }
 


### PR DESCRIPTION
setCursorBufferPosition on L91 is thrashing scrollToBufferPosition on L90.
Passing autoscroll: false in the options for setCursorBufferPosition fixes
this.

Fixes #132