### PR TITLE
Allow end-user configuration of tags path relative to project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Display the list of functions/methods in the editor via `cmd-r` in Atom.
 
-If your project has a `tags`/`.tags`/`TAGS`/`.TAGS` file at the root then
-following are supported:
+If your project has a `tags`/`.tags`/`TAGS`/`.TAGS` file at the root or at a
+custom directory defined in `tagsDirectory` then the following are supported:
 
 |Command|Description|Keybinding (Linux)|Keybinding (OS X)|Keybinding (Windows)|
 |-------|-----------|------------------|-----------------|--------------------|

--- a/lib/load-tags-handler.coffee
+++ b/lib/load-tags-handler.coffee
@@ -2,16 +2,18 @@ async = require 'async'
 ctags = require 'ctags'
 getTagsFile = require './get-tags-file'
 
-module.exports = (directoryPaths) ->
+module.exports = (tagDirectoryObjects) ->
   async.each(
-    directoryPaths,
-    (directoryPath, done) ->
-      tagsFilePath = getTagsFile(directoryPath)
+    tagDirectoryObjects,
+    ({tagsPath, projectPath}, done) ->
+      tagsFilePath = getTagsFile(tagsPath)
       return done() unless tagsFilePath
 
       stream = ctags.createReadStream(tagsFilePath)
       stream.on 'data', (tags) ->
-        tag.directory = directoryPath for tag in tags
+        for tag in tags
+          tag.projectPath = projectPath
+          tag.directory = tagsPath
         emit('tags', tags)
       stream.on('end', done)
       stream.on('error', done)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -4,7 +4,10 @@ module.exports =
       default: true
       type: 'boolean'
       description: 'Force ctags to use the name of the current file\'s language in Atom when generating tags. By default, ctags automatically selects the language of a source file, ignoring those files whose language cannot be determined. This option forces the specified language to be used instead of automatically selecting the language based upon its extension.'
-
+    tagsDirectory:
+      default: './'
+      type: 'string'
+      description: 'A directory relative to your project path where symbols-view will look for your tags file. By default this is set to project root.'
   activate: ->
     @stack = []
 

--- a/lib/symbols-view.coffee
+++ b/lib/symbols-view.coffee
@@ -37,12 +37,13 @@ class SymbolsView extends SelectListView
 
   getFilterKey: -> 'name'
 
-  viewForItem: ({position, name, file, directory}) ->
+  viewForItem: ({position, name, file, directory, projectPath}) ->
     # Style matched characters in search results
     matches = match(name, @getFilterQuery())
 
+    file = path.relative(projectPath, path.join(directory, file))
     if atom.project.getPaths().length > 1
-      file = path.join(path.basename(directory), file)
+      file = path.join(path.basename(projectPath), file)
 
     $$ ->
       @li class: 'two-lines', =>
@@ -63,7 +64,8 @@ class SymbolsView extends SelectListView
 
   confirmed: (tag) ->
     if tag.file and not fs.isFileSync(path.join(tag.directory, tag.file))
-      @setError('Selected file does not exist')
+      @setError("Selected file does not exist. Try running ctags with the " +
+                "--tag-relative option inside your project directory.")
       setTimeout((=> @setError()), 2000)
     else
       @cancel()

--- a/spec/fixtures/js/tagsDir/tags
+++ b/spec/fixtures/js/tagsDir/tags
@@ -1,0 +1,10 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Exuberant Ctags	//
+!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
+!_TAG_PROGRAM_VERSION	5.8	//
+callMeMaybe	../tagged.js	/^function callMeMaybe() {$/;"	f
+duplicate	../tagged-duplicate.js	/^function duplicate() {$/;"	f
+duplicate	../tagged.js	/^function duplicate() {$/;"	f
+thisIsCrazy	../tagged.js	/^var thisIsCrazy = true;$/;"	v


### PR DESCRIPTION
Allow user to specify the directory, relative to the root of each project
open within Atom, where symbols-view looks for the `tags` file, using
the `tagsDirectory` config variable.

This only effects `toggle-project-symbols`. The impetus behind this commit
is to allow popular confirations, such as storing tags files in the `.git`
directory, to work. The change required additional information on each
`tag` object, mainly specifiying the path of the project the tag was generated
for. This was to a) easily display the project directory when multiple projects
were open and b) to programatically resolve the full path of the symbol's file
when generating symbols relative to root.

This also required adding a configuration variable `tagsDirectory`, which should
be a directory relative to the project root that contains the tags file.

Also refactored the reloadTags method inside of watchTagsFiles into a separate
instance method, with a different name (triggerReloadTags) so that it didn't
shadow the instance attribute reloadTags, and could be used in the configuration
watcher for the new `tagsDirectory` configuration variable.

Added an appropriate test to run `toggle-project-symbols` with a relative
`tagsDirectory` config set.