### PR TITLE
Added support for tags in .git directory

### DIFF
--- a/lib/get-tags-file.coffee
+++ b/lib/get-tags-file.coffee
@@ -16,8 +16,8 @@ module.exports = (directoryPath) ->
   tagsFile = path.join(directoryPath, ".TAGS")
   return tagsFile if fs.isFileSync(tagsFile)
 
-  tagsFile = path.join(directoryPath, ".git/tags")
+  tagsFile = path.join(directoryPath, ".git", "tags")
   return tagsFile if fs.isFileSync(tagsFile)
 
-  tagsFile = path.join(directoryPath, ".git/TAGS")
+  tagsFile = path.join(directoryPath, ".git", "TAGS")
   return tagsFile if fs.isFileSync(tagsFile)

--- a/lib/get-tags-file.coffee
+++ b/lib/get-tags-file.coffee
@@ -15,3 +15,9 @@ module.exports = (directoryPath) ->
 
   tagsFile = path.join(directoryPath, ".TAGS")
   return tagsFile if fs.isFileSync(tagsFile)
+
+  tagsFile = path.join(directoryPath, ".git/tags")
+  return tagsFile if fs.isFileSync(tagsFile)
+
+  tagsFile = path.join(directoryPath, ".git/TAGS")
+  return tagsFile if fs.isFileSync(tagsFile)


### PR DESCRIPTION
I keep my tag files in .git/ subdirectory for all my projects which is handy -
no need to update `.gitignores` file for project I don't own.