### PR TITLE
Fix go-to-declaration for Ruby identifiers in some cases

### DIFF
--- a/lib/tag-reader.coffee
+++ b/lib/tag-reader.coffee
@@ -13,7 +13,7 @@ module.exports =
       cursor = editor.getLastCursor()
       scopes = cursor.getScopeDescriptor().getScopesArray()
       rubyScopes = scopes.filter (scope) -> /^source\.ruby($|\.)/.test(scope)
-      wordRegex = /[a-zA-Z_][\w!?]*/g if rubyScopes.length
+      wordRegex = /[\w!?]*/g if rubyScopes.length
 
       range = cursor.getCurrentWordBufferRange({wordRegex})
       symbol = editor.getTextInRange(range)

--- a/lib/tag-reader.coffee
+++ b/lib/tag-reader.coffee
@@ -7,15 +7,18 @@ handlerPath = require.resolve './load-tags-handler'
 
 module.exports =
   find: (editor, callback) ->
-    cursor = editor.getLastCursor()
-    scopes = cursor.getScopeDescriptor().getScopesArray()
-    rubyScopes = scopes.filter (scope) -> /^source\.ruby($|\.)/.test(scope)
-    wordRegex = /[a-zA-Z_][\w!?]*/g if rubyScopes.length
+    symbol = editor.getSelectedText()
 
-    range = cursor.getCurrentWordBufferRange({wordRegex})
-    symbol = editor.getTextInRange(range)
+    unless symbol
+      cursor = editor.getLastCursor()
+      scopes = cursor.getScopeDescriptor().getScopesArray()
+      rubyScopes = scopes.filter (scope) -> /^source\.ruby($|\.)/.test(scope)
+      wordRegex = /[a-zA-Z_][\w!?]*/g if rubyScopes.length
 
-    unless symbol?.length > 0
+      range = cursor.getCurrentWordBufferRange({wordRegex})
+      symbol = editor.getTextInRange(range)
+
+    unless symbol
       return process.nextTick -> callback(null, [])
 
     allTags = []

--- a/lib/tag-reader.coffee
+++ b/lib/tag-reader.coffee
@@ -6,6 +6,14 @@ _ = require 'underscore-plus'
 
 handlerPath = require.resolve './load-tags-handler'
 
+wordAtCursor = (text, cursorIndex, wordSeparator) ->
+  beforeCursor = text.slice(0, cursorIndex)
+  afterCursor = text.slice(cursorIndex)
+  beforeCursorWordBegins = beforeCursor.lastIndexOf(wordSeparator) + 1
+  afterCursorWordEnds = afterCursor.indexOf(wordSeparator)
+  afterCursorWordEnds = afterCursor.length if afterCursorWordEnds is -1
+  beforeCursor.slice(beforeCursorWordBegins) + afterCursor.slice(0, afterCursorWordEnds)
+
 module.exports =
   find: (editor, callback) ->
     symbols = []
@@ -20,21 +28,31 @@ module.exports =
       rubyScopes = scope.getScopesArray().filter (s) -> /^source\.ruby($|\.)/.test(s)
 
       wordRegExp = if rubyScopes.length
-        nonWordCharacters = _.escapeRegExp(editor.config.get('editor.nonWordCharacters', {scope}))
-        new RegExp("[^\\s#{nonWordCharacters}]+([!?]|\\s*=)?|[<=>]+", 'g')
+        nonWordCharacters = editor.config.get 'editor.nonWordCharacters', {scope}
+        # Allow special handling for fully-qualified ruby constants
+        nonWordCharacters = nonWordCharacters.replace(/:/g, '')
+        new RegExp("[^\\s#{_.escapeRegExp nonWordCharacters}]+([!?]|\\s*=>?)?|[<=>]+", 'g')
       else
         cursor.wordRegExp()
+
+      addSymbol = (symbol) ->
+        if rubyScopes.length
+          # Normalize assignment syntax
+          symbols.push symbol.replace(/\s+=$/, '=') if /\s+=?$/.test(symbol)
+          # Strip away assignment & hashrocket syntax
+          symbols.push symbol.replace(/\s+=>?$/, '')
+        else
+          symbols.push symbol
 
       # Can't use `getCurrentWordBufferRange` here because we want to select
       # the last match of the potential 2 matches under cursor.
       editor.scanInBufferRange wordRegExp, cursor.getCurrentLineBufferRange(), ({range, match}) ->
         if range.containsPoint(cursorPosition)
           symbol = match[0]
-          if /\s+=$/.test(symbol)
-            symbols.push symbol.replace(/\s+=$/, '=')
-            symbols.push symbol.replace(/\s+=$/, '')
-          else
-            symbols.push symbol
+          addSymbol symbol
+          if rubyScopes.length and symbol.indexOf(':') > -1
+            # Beside fully-qualified Ruby constant, also look up the bare word under cursor
+            addSymbol wordAtCursor(symbol, cursorPosition.column - range.start.column, ':')
 
     unless symbols.length
       return process.nextTick -> callback(null, [])

--- a/lib/tag-reader.coffee
+++ b/lib/tag-reader.coffee
@@ -7,12 +7,12 @@ handlerPath = require.resolve './load-tags-handler'
 
 module.exports =
   find: (editor, callback) ->
-    if editor.getLastCursor().getScopeDescriptor().getScopesArray().indexOf('source.ruby') isnt -1
-      # Include ! and ? in word regular expression for ruby files
-      range = editor.getLastCursor().getCurrentWordBufferRange(wordRegex: /[\w!?]*/g)
-    else
-      range = editor.getLastCursor().getCurrentWordBufferRange()
+    cursor = editor.getLastCursor()
+    scopes = cursor.getScopeDescriptor().getScopesArray()
+    rubyScopes = scopes.filter (scope) -> /^source\.ruby($|\.)/.test(scope)
+    wordRegex = /[a-zA-Z_][\w!?]*/g if rubyScopes.length
 
+    range = cursor.getCurrentWordBufferRange({wordRegex})
     symbol = editor.getTextInRange(range)
 
     unless symbol?.length > 0

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "fs-plus": "^2.0.0",
     "fuzzaldrin": "^2.1.0",
     "humanize-plus": "1.4.2",
-    "temp": "~0.8.1"
+    "temp": "~0.8.1",
+    "underscore-plus": "~1.6.6"
   },
   "configSchema": {
     "useEditorGrammarAsCtagsLanguage": {

--- a/spec/fixtures/ruby/file1.rb
+++ b/spec/fixtures/ruby/file1.rb
@@ -1,4 +1,6 @@
-def Foo
+module A::Foo
+  B = 'b'
+
   def bar!
 
   end
@@ -18,5 +20,7 @@ if bar?
   baz
   bar!
 elsif !bar!
-  baz=
+  baz= 1
+  baz = 2
+  Foo = 3
 end

--- a/spec/fixtures/ruby/file1.rb
+++ b/spec/fixtures/ruby/file1.rb
@@ -23,4 +23,7 @@ elsif !bar!
   baz= 1
   baz = 2
   Foo = 3
+  { :baz => 4 }
+  A::Foo::B
+  C::Foo::B
 end

--- a/spec/fixtures/ruby/file1.rb
+++ b/spec/fixtures/ruby/file1.rb
@@ -9,9 +9,14 @@ def Foo
 
   def baz
   end
+
+  def baz=(*)
+  end
 end
 
 if bar?
   baz
   bar!
+elsif !bar!
+  baz=
 end

--- a/spec/fixtures/ruby/file1.rb
+++ b/spec/fixtures/ruby/file1.rb
@@ -26,4 +26,8 @@ elsif !bar!
   { :baz => 4 }
   A::Foo::B
   C::Foo::B
+  D::Foo::E
+end
+
+module D::Foo
 end

--- a/spec/fixtures/ruby/tags
+++ b/spec/fixtures/ruby/tags
@@ -4,7 +4,7 @@
 !_TAG_PROGRAM_NAME	Exuberant Ctags	//
 !_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
 !_TAG_PROGRAM_VERSION	5.8	//
-Foo	file1.rb	/^def Foo$/;"	f
+Foo	file1.rb	/^module A::Foo$/;"	m
 bar!	file1.rb	/^  def bar!$/;"	f	class:Foo
 bar?	file1.rb	/^  def bar?$/;"	f	class:Foo
 baz	file1.rb	/^  def baz$/;"	f	class:Foo

--- a/spec/fixtures/ruby/tags
+++ b/spec/fixtures/ruby/tags
@@ -4,6 +4,9 @@
 !_TAG_PROGRAM_NAME	Exuberant Ctags	//
 !_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
 !_TAG_PROGRAM_VERSION	5.8	//
+A::Foo	file1.rb	/^module A::Foo$/;"	m
+A::Foo::B	file1.rb	/^  B = 'b'$/;"	C
+B	file1.rb	/^  B = 'b'$/;"	C
 Foo	file1.rb	/^module A::Foo$/;"	m
 bar!	file1.rb	/^  def bar!$/;"	f	class:Foo
 bar?	file1.rb	/^  def bar?$/;"	f	class:Foo

--- a/spec/fixtures/ruby/tags
+++ b/spec/fixtures/ruby/tags
@@ -8,3 +8,4 @@ Foo	file1.rb	/^def Foo$/;"	f
 bar!	file1.rb	/^  def bar!$/;"	f	class:Foo
 bar?	file1.rb	/^  def bar?$/;"	f	class:Foo
 baz	file1.rb	/^  def baz$/;"	f	class:Foo
+baz=	file1.rb	/^  def baz=(*)$/;"	f	class:Foo

--- a/spec/fixtures/ruby/tags
+++ b/spec/fixtures/ruby/tags
@@ -7,6 +7,7 @@
 A::Foo	file1.rb	/^module A::Foo$/;"	m
 A::Foo::B	file1.rb	/^  B = 'b'$/;"	C
 B	file1.rb	/^  B = 'b'$/;"	C
+D::Foo	file1.rb	/^module D::Foo$/;"	m
 Foo	file1.rb	/^module A::Foo$/;"	m
 bar!	file1.rb	/^  def bar!$/;"	f	class:Foo
 bar?	file1.rb	/^  def bar?$/;"	f	class:Foo

--- a/spec/symbols-view-spec.coffee
+++ b/spec/symbols-view-spec.coffee
@@ -357,7 +357,7 @@ describe "SymbolsView", ->
 
       runs ->
         spyOn(SymbolsView.prototype, "moveToPosition").andCallThrough()
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([26, 2])
+        atom.workspace.getActiveTextEditor().setCursorBufferPosition([26, 10])
         atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
 
       waitsFor ->
@@ -374,6 +374,15 @@ describe "SymbolsView", ->
 
       runs ->
         expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [0, 0]
+        SymbolsView::moveToPosition.reset()
+        atom.workspace.getActiveTextEditor().setCursorBufferPosition([28, 5])
+        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
+
+      waitsFor ->
+        SymbolsView::moveToPosition.callCount is 1
+
+      runs ->
+        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [31, 0]
 
     describe "return from declaration", ->
       it "doesn't do anything when no go-to have been triggered", ->

--- a/spec/symbols-view-spec.coffee
+++ b/spec/symbols-view-spec.coffee
@@ -258,7 +258,7 @@ describe "SymbolsView", ->
 
       runs ->
         spyOn(SymbolsView.prototype, "moveToPosition").andCallThrough()
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([13, 4])
+        atom.workspace.getActiveTextEditor().setCursorBufferPosition([16, 4])
         atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
 
       waitsForPromise ->
@@ -270,7 +270,7 @@ describe "SymbolsView", ->
       runs ->
         expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [5, 2]
         SymbolsView::moveToPosition.reset()
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([14, 2])
+        atom.workspace.getActiveTextEditor().setCursorBufferPosition([17, 2])
         atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
 
       waitsFor ->
@@ -279,7 +279,7 @@ describe "SymbolsView", ->
       runs ->
         expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [9, 2]
         SymbolsView::moveToPosition.reset()
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([15, 5])
+        atom.workspace.getActiveTextEditor().setCursorBufferPosition([18, 5])
         atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
 
       waitsFor ->
@@ -287,6 +287,24 @@ describe "SymbolsView", ->
 
       runs ->
         expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [1, 2]
+        SymbolsView::moveToPosition.reset()
+        atom.workspace.getActiveTextEditor().setCursorBufferPosition([19, 7])
+        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
+
+      waitsFor ->
+        SymbolsView::moveToPosition.callCount is 1
+
+      runs ->
+        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [1, 2]
+        SymbolsView::moveToPosition.reset()
+        atom.workspace.getActiveTextEditor().setCursorBufferPosition([20, 5])
+        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
+
+      waitsFor ->
+        SymbolsView::moveToPosition.callCount is 1
+
+      runs ->
+        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [12, 2]
 
     describe "return from declaration", ->
       it "doesn't do anything when no go-to have been triggered", ->

--- a/spec/symbols-view-spec.coffee
+++ b/spec/symbols-view-spec.coffee
@@ -258,7 +258,7 @@ describe "SymbolsView", ->
 
       runs ->
         spyOn(SymbolsView.prototype, "moveToPosition").andCallThrough()
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([16, 4])
+        atom.workspace.getActiveTextEditor().setCursorBufferPosition([18, 4])
         atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
 
       waitsForPromise ->
@@ -268,34 +268,16 @@ describe "SymbolsView", ->
         SymbolsView::moveToPosition.callCount is 1
 
       runs ->
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [5, 2]
+        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [7, 2]
         SymbolsView::moveToPosition.reset()
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([17, 2])
+        atom.workspace.getActiveTextEditor().setCursorBufferPosition([19, 2])
         atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
 
       waitsFor ->
         SymbolsView::moveToPosition.callCount is 1
 
       runs ->
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [9, 2]
-        SymbolsView::moveToPosition.reset()
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([18, 5])
-        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
-
-      waitsFor ->
-        SymbolsView::moveToPosition.callCount is 1
-
-      runs ->
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [1, 2]
-        SymbolsView::moveToPosition.reset()
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([19, 7])
-        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
-
-      waitsFor ->
-        SymbolsView::moveToPosition.callCount is 1
-
-      runs ->
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [1, 2]
+        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [11, 2]
         SymbolsView::moveToPosition.reset()
         atom.workspace.getActiveTextEditor().setCursorBufferPosition([20, 5])
         atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
@@ -304,7 +286,55 @@ describe "SymbolsView", ->
         SymbolsView::moveToPosition.callCount is 1
 
       runs ->
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [12, 2]
+        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [3, 2]
+        SymbolsView::moveToPosition.reset()
+        atom.workspace.getActiveTextEditor().setCursorBufferPosition([21, 7])
+        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
+
+      waitsFor ->
+        SymbolsView::moveToPosition.callCount is 1
+
+      runs ->
+        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [3, 2]
+
+    it "handles jumping to assignment ruby method definitions", ->
+      atom.project.setPaths([temp.mkdirSync("atom-symbols-view-ruby-")])
+      fs.copySync(path.join(__dirname, 'fixtures', 'ruby'), atom.project.getPaths()[0])
+
+      waitsForPromise ->
+        atom.packages.activatePackage('language-ruby')
+
+      waitsForPromise ->
+        atom.workspace.open 'file1.rb'
+
+      runs ->
+        spyOn(SymbolsView.prototype, "moveToPosition").andCallThrough()
+        atom.workspace.getActiveTextEditor().setCursorBufferPosition([22, 5])
+        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
+
+      waitsFor ->
+        SymbolsView::moveToPosition.callCount is 1
+
+      runs ->
+        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [14, 2]
+        SymbolsView::moveToPosition.reset()
+        atom.workspace.getActiveTextEditor().setCursorBufferPosition([23, 5])
+        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
+
+      waitsFor ->
+        SymbolsView::moveToPosition.callCount is 1
+
+      runs ->
+        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [14, 2]
+        SymbolsView::moveToPosition.reset()
+        atom.workspace.getActiveTextEditor().setCursorBufferPosition([24, 5])
+        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
+
+      waitsFor ->
+        SymbolsView::moveToPosition.callCount is 1
+
+      runs ->
+        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [0, 0]
 
     describe "return from declaration", ->
       it "doesn't do anything when no go-to have been triggered", ->

--- a/spec/symbols-view-spec.coffee
+++ b/spec/symbols-view-spec.coffee
@@ -335,6 +335,45 @@ describe "SymbolsView", ->
 
       runs ->
         expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [0, 0]
+        SymbolsView::moveToPosition.reset()
+        atom.workspace.getActiveTextEditor().setCursorBufferPosition([25, 5])
+        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
+
+      waitsFor ->
+        SymbolsView::moveToPosition.callCount is 1
+
+      runs ->
+        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [11, 2]
+
+    it "handles jumping to fully qualified ruby constant definitions", ->
+      atom.project.setPaths([temp.mkdirSync("atom-symbols-view-ruby-")])
+      fs.copySync(path.join(__dirname, 'fixtures', 'ruby'), atom.project.getPaths()[0])
+
+      waitsForPromise ->
+        atom.packages.activatePackage('language-ruby')
+
+      waitsForPromise ->
+        atom.workspace.open 'file1.rb'
+
+      runs ->
+        spyOn(SymbolsView.prototype, "moveToPosition").andCallThrough()
+        atom.workspace.getActiveTextEditor().setCursorBufferPosition([26, 2])
+        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
+
+      waitsFor ->
+        SymbolsView::moveToPosition.callCount is 1
+
+      runs ->
+        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [1, 2]
+        SymbolsView::moveToPosition.reset()
+        atom.workspace.getActiveTextEditor().setCursorBufferPosition([27, 5])
+        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
+
+      waitsFor ->
+        SymbolsView::moveToPosition.callCount is 1
+
+      runs ->
+        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual [0, 0]
 
     describe "return from declaration", ->
       it "doesn't do anything when no go-to have been triggered", ->


### PR DESCRIPTION
- Fixes jumping to `foo?`/`foo!` declarations when the current scope is an ERB template.
- **New feature:** enables selecting text such as `Foo::Bar` and jumping to that as a tag to look up. When there is no selection, falls back to word under cursor.

More details in commit messages.