### PR TITLE
Fix return-from-declaration when navigating to an unsaved file

### DIFF
--- a/lib/go-back-view.coffee
+++ b/lib/go-back-view.coffee
@@ -6,5 +6,14 @@ class GoBackView extends SymbolsView
     previousTag = @stack.pop()
     return unless previousTag?
 
-    atom.workspace.open(previousTag.file).then =>
+    restorePosition = =>
       @moveToPosition(previousTag.position, false) if previousTag.position
+
+    previousEditor = atom.workspace.getTextEditors().find (e) -> e.id is previousTag.editorId
+
+    if previousEditor
+      pane = atom.workspace.paneForItem(previousEditor)
+      pane.setActiveItem(previousEditor)
+      restorePosition()
+    else if previousTag.file
+      atom.workspace.open(previousTag.file).then restorePosition

--- a/lib/symbols-view.coffee
+++ b/lib/symbols-view.coffee
@@ -72,6 +72,7 @@ class SymbolsView extends SelectListView
   openTag: (tag) ->
     if editor = atom.workspace.getActiveTextEditor()
       previous =
+        editorId: editor.id
         position: editor.getCursorBufferPosition()
         file: editor.getURI()
 


### PR DESCRIPTION
Fixes the following bug:

* Create a new file, but don't save it.
* Use go-to-declaration to jump to the definition of the word under cursor.
* Use return-from-declaration to jump back.

Expected: the active text editor focus returns to unsaved file.

Actual: a new blank file tab gets opened.