### PR TITLE
Also remove escape char from tag before search

### DIFF
--- a/lib/symbols-view.coffee
+++ b/lib/symbols-view.coffee
@@ -98,8 +98,8 @@ class SymbolsView extends SelectListView
     @focusFilterEditor()
 
   getTagLine: (tag) ->
-    # Remove leading /^ and trailing $/
-    pattern = tag.pattern?.replace(/(^^\/\^)|(\$\/$)/g, '').trim()
+    # Remove leading /^ , trailing $/ , and escape char (\)
+    pattern = tag.pattern?.replace(/(^^\/\^)|(\$\/$)|(\\)/g, '').trim()
 
     return unless pattern
     file = path.join(tag.directory, tag.file)


### PR DESCRIPTION
Not just leading and trailing regex chars must be removed. Ex:  /^
myFunction() { \/\/ a comment $/

Fixes : https://github.com/atom/symbols-view/issues/178