### PR TITLE
If present, use tag line number instead of search pattern.

### DIFF
--- a/lib/symbols-view.coffee
+++ b/lib/symbols-view.coffee
@@ -98,6 +98,8 @@ class SymbolsView extends SelectListView
     @focusFilterEditor()
 
   getTagLine: (tag) ->
+    return new Point(tag.lineNumber - 1, 0) if tag.lineNumber
+
     # Remove leading /^ and trailing $/
     pattern = tag.pattern?.replace(/(^^\/\^)|(\$\/$)/g, '').trim()
 

--- a/spec/fixtures/c/sample.c
+++ b/spec/fixtures/c/sample.c
@@ -1,0 +1,6 @@
+#define UNUSED(x) (void)(x)
+
+static void f(int x)
+{
+  UNUSED(x);
+}

--- a/spec/fixtures/c/tags
+++ b/spec/fixtures/c/tags
@@ -1,0 +1,8 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Exuberant Ctags	//
+!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
+!_TAG_PROGRAM_VERSION	5.9~svn20110310	//
+UNUSED	sample.c	1;"	d	file:
+f	sample.c	/^static void f(int x)$/;"	f	file:

--- a/spec/symbols-view-spec.coffee
+++ b/spec/symbols-view-spec.coffee
@@ -220,6 +220,28 @@ describe "SymbolsView", ->
       runs ->
         expect(editor.getCursorBufferPosition()).toEqual [2, 0]
 
+    it "correctly moves the cursor to the declaration of a C preprocessor macro", ->
+      atom.project.setPaths([temp.mkdirSync("atom-symbols-view-c-")])
+      fs.copySync(path.join(__dirname, 'fixtures', 'c'), atom.project.getPaths()[0])
+
+      waitsForPromise ->
+        atom.packages.activatePackage('language-c')
+
+      waitsForPromise ->
+        atom.workspace.open "sample.c"
+
+      runs ->
+        editor = atom.workspace.getActiveTextEditor()
+        editor.setCursorBufferPosition([4, 4])
+        spyOn(SymbolsView.prototype, "moveToPosition").andCallThrough()
+        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration')
+
+      waitsFor ->
+        SymbolsView::moveToPosition.callCount is 1
+
+      runs ->
+        expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+
     it "displays matches when more than one exists and opens the selected match", ->
       waitsForPromise ->
         atom.workspace.open(directory.resolve("tagged.js"))


### PR DESCRIPTION
Instead of a search pattern, line numbers are emmited by ctags in some cases.
This is true for C preprocessor macros, for example.
