### PR TITLE
Add Provider API

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -90,4 +90,8 @@ export default {
     this.goBackView = new GoBackView(this.stack);
     return this.goBackView;
   },
+
+  consumeProvider_0_0_1() {
+    // No-op
+  },
 };

--- a/package.json
+++ b/package.json
@@ -49,5 +49,12 @@
     "eslint-plugin-jasmine": "^2.2.0",
     "eslint-plugin-prefer-object-spread": "^1.1.0",
     "eslint-plugin-react": "^5.2.2"
+  },
+  "consumedServices": {
+    "symbols.provider": {
+      "versions": {
+        "0.0.1": "consumeProvider_0_0_1"
+      }
+    }
   }
 }


### PR DESCRIPTION
🚨 **WIP - Do Not Merge** 🚨 

### Description of the Change

This PR seeks to implement the proposal described at https://github.com/atom/symbols-view/wiki/v1-Proposal.

### Benefits

* External packages will be able to extend the functionality included in `symbols-view`, by providing grammar-specific strategies for navigation to symbols definitions or references
* Users will have new functionality allowing them to view references to a symbol and navigate to those references
* ctags support in `symbols-view` will be encapsulated in a provider, allowing for further enhancement of `symbols-view` in ways that might go beyond what ctags can allow

### Possible Drawbacks

Many packages may be directly integrating with `symbols-view` by activating the package and attempting to use functions that are not part of a public API. Such packages will need to be updated to continue to function correctly.

### Applicable Issues

* #95 
* #70 
* joefitzgerald/go-plus#123
* joefitzgerald/go-plus#33
* joefitzgerald/go-plus#11

### Tasks

- [ ] Add symbol provider API
- [ ] Extract `CtagsProvider` and register it like any other provider
- [ ] Rewrite `go-to-view.js` to use `etch`
- [ ] Rewrite `go-back-view.js` to use `etch` 
- [ ] Add find references to provider API
- [ ] Add find references view
- [ ] Add find references commands, keymaps, menu(s)

/cc @zmb3 

🚨 **WIP - Do Not Merge** 🚨 