### PR TITLE
Added symbols-view.extraCtagsArguments

### DIFF
--- a/lib/tag-generator.js
+++ b/lib/tag-generator.js
@@ -83,6 +83,8 @@ export default class TagGenerator {
       }
     }
 
+    Array.prototype.push.apply(args, atom.config.get('symbols-view.extraCtagsArguments'));
+
     args.push('-nf', '-', this.path);
 
     return new Promise((resolve) => {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,14 @@
       "type": "boolean",
       "description": "Force ctags to use the name of the current file's language in Atom when generating tags. By default, ctags automatically selects the language of a source file, ignoring those files whose language cannot be determined. This option forces the specified language to be used instead of automatically selecting the language based upon its extension."
     },
+    "extraCtagsArguments": {
+      "default": [],
+      "type": "array",
+      "description": "Extra command line arguments for ctags (Comma separated)",
+      "items": {
+        "type": "string"
+      }
+    },
     "quickJumpToFileSymbol": {
       "default": true,
       "type": "boolean",

--- a/spec/symbols-view-spec.js
+++ b/spec/symbols-view-spec.js
@@ -193,6 +193,21 @@ describe('SymbolsView', () => {
 
       runs(() => expect(tags.length).toBe(0));
     });
+
+    describe('when extraCtagsArguments is used', () => {
+      it("finds no symbols when the arguments contain --help", () => {
+        atom.config.set('symbols-view.extraCtagsArguments', ['--help']);
+
+        let tags = [];
+
+        waitsForPromise(() => {
+          const sampleJsPath = directory.resolve('sample.js');
+          return new TagGenerator(sampleJsPath).generate().then(o => tags = o);
+        });
+
+        runs(() => expect(tags.length).toBe(0));
+      });
+    });
   });
 
   describe('go to declaration', () => {


### PR DESCRIPTION
### General Description

This allows to add extra arguments to the ctags invocation
used by file-view, an example use case is using --options and supplying
an extra ctags config file which should only be used with Atom. That is
the user doesn't want to place it in $HOME/.ctags or a similar location.

### Description of the Change

I added a simple array config that is added as additional arguments to the
ctags invocation used by file-view.

### Benefits

A user can set any extra arguments he wants Atom to use for invoking ctags
for example giving an Atom specific config file he doesn't want to use globally.

### Possible Drawbacks

It's an extra configuration value a user can use to screw up symbols-view 😆 