### PR TITLE
Add asciidoc support

### DIFF
--- a/lib/ctags-config
+++ b/lib/ctags-config
@@ -151,3 +151,7 @@
 --regex-latex=/\\section\*\{([^}]*)\}/\1/s,section/
 --regex-latex=/\\subsection\*\{([^}]*)\}/\1/t,subsection/
 --regex-latex=/\\subsubsection\*\{([^}]*)\}/\1/u,subsubsection/
+
+--langdef=asciidoc
+--langmap=asciidoc:.ad.adoc.asciidoc
+--regex-asciidoc=/^[=]+[ \t]+(.*)/\1/h,heading/


### PR DESCRIPTION
All asciidoc headings (starting with =) will be tagged. It allows to navigate to them.
