### PR TITLE
Replace atom-space-pen-views with atom-select-list

### DIFF
--- a/lib/file-view.js
+++ b/lib/file-view.js
@@ -1,4 +1,4 @@
-'use babel';
+/** @babel */
 
 import { $$ } from 'atom-space-pen-views';
 import { CompositeDisposable } from 'atom';

--- a/lib/file-view.js
+++ b/lib/file-view.js
@@ -1,17 +1,13 @@
 /** @babel */
 
-import { $$ } from 'atom-space-pen-views';
 import { CompositeDisposable } from 'atom';
 import SymbolsView from './symbols-view';
 import TagGenerator from './tag-generator';
 import { match } from 'fuzzaldrin';
 
-// TODO: remove references to logical display buffer when it is released.
-
 export default class FileView extends SymbolsView {
-  initialize() {
-    super.initialize(...arguments);
-
+  constructor(stack) {
+    super(stack);
     this.cachedTags = {};
 
     this.editorsSubscription = atom.workspace.observeTextEditors(editor => {
@@ -32,33 +28,37 @@ export default class FileView extends SymbolsView {
 
   destroy() {
     this.editorsSubscription.dispose();
-    super.destroy(...arguments);
+    return super.destroy();
   }
 
-  viewForItem({position, name}) {
+  elementForItem({position, name}) {
     // Style matched characters in search results
-    const matches = match(name, this.getFilterQuery());
+    const matches = match(name, this.selectListView.getFilterQuery());
 
-    return $$(function() {
-      return this.li({class: 'two-lines'}, () => {
-        this.div({class: 'primary-line'}, () => FileView.highlightMatches(this, name, matches));
-        return this.div(`Line ${position.row + 1}`, {class: 'secondary-line'});
-      });
-    });
+    const li = document.createElement('li');
+    li.classList.add('two-lines');
+
+    const primaryLine = document.createElement('div');
+    primaryLine.classList.add('primary-line');
+    primaryLine.appendChild(SymbolsView.highlightMatches(this, name, matches));
+    li.appendChild(primaryLine);
+
+    const secondaryLine = document.createElement('div');
+    secondaryLine.classList.add('secondary-line');
+    secondaryLine.textContent = `Line ${position.row + 1}`;
+    li.appendChild(secondaryLine);
+
+    return li;
   }
 
-  selectItemView() {
-    super.selectItemView(...arguments);
-    if (atom.config.get('symbols-view.quickJumpToFileSymbol')) {
-      const item = this.getSelectedItem();
-      if (item != null) {
-        this.openTag(item);
-      }
+  didChangeSelection(item) {
+    if (atom.config.get('symbols-view.quickJumpToFileSymbol') && item) {
+      this.openTag(item);
     }
   }
 
-  cancelled() {
-    super.cancelled(...arguments);
+  async didCancelSelection() {
+    await this.cancel();
     const editor = this.getEditor();
     if (this.initialState && editor) {
       this.deserializeEditorState(editor, this.initialState);
@@ -66,9 +66,9 @@ export default class FileView extends SymbolsView {
     this.initialState = null;
   }
 
-  toggle() {
+  async toggle() {
     if (this.panel.isVisible()) {
-      this.cancel();
+      await this.cancel();
     }
     const filePath = this.getPath();
     if (filePath) {
@@ -82,13 +82,8 @@ export default class FileView extends SymbolsView {
   }
 
   serializeEditorState(editor) {
-    let scrollTop;
     const editorElement = atom.views.getView(editor);
-    if (editorElement.logicalDisplayBuffer) {
-      scrollTop = editorElement.getScrollTop();
-    } else {
-      scrollTop = editor.getScrollTop();
-    }
+    const scrollTop = editorElement.getScrollTop();
 
     return {
       bufferRanges: editor.getSelectedBufferRanges(),
@@ -100,11 +95,7 @@ export default class FileView extends SymbolsView {
     const editorElement = atom.views.getView(editor);
 
     editor.setSelectedBufferRanges(bufferRanges);
-    if (editorElement.logicalDisplayBuffer) {
-      return editorElement.setScrollTop(scrollTop);
-    } else {
-      return editor.setScrollTop(scrollTop);
-    }
+    editorElement.setScrollTop(scrollTop);
   }
 
   getEditor() {
@@ -125,23 +116,25 @@ export default class FileView extends SymbolsView {
     return undefined;
   }
 
-  populate(filePath) {
+  async populate(filePath) {
     const tags = this.cachedTags[filePath];
-    this.list.empty();
-    this.setLoading('Generating symbols\u2026');
     if (tags) {
-      this.setMaxItems(Infinity);
-      this.setItems(tags);
+      await this.selectListView.update({items: tags});
     } else {
-      this.generateTags(filePath);
+      await this.selectListView.update({
+        items: [],
+        loadingMessage: 'Generating symbols\u2026',
+      });
+      await this.selectListView.update({
+        items: await this.generateTags(filePath),
+        loadingMessage: null,
+      });
     }
   }
 
-  generateTags(filePath) {
-    return new TagGenerator(filePath, this.getScopeName()).generate().then((tags) => {
-      this.cachedTags[filePath] = tags;
-      this.setMaxItems(Infinity);
-      this.setItems(tags);
-    });
+  async generateTags(filePath) {
+    const generator = new TagGenerator(filePath, this.getScopeName());
+    this.cachedTags[filePath] = await generator.generate();
+    return this.cachedTags[filePath];
   }
 }

--- a/lib/get-tags-file.js
+++ b/lib/get-tags-file.js
@@ -1,4 +1,4 @@
-'use babel';
+/** @babel */
 
 import path from 'path';
 import fs from 'fs-plus';

--- a/lib/go-back-view.js
+++ b/lib/go-back-view.js
@@ -1,4 +1,4 @@
-'use babel';
+/** @babel */
 
 import SymbolsView from './symbols-view';
 

--- a/lib/go-to-view.js
+++ b/lib/go-to-view.js
@@ -39,13 +39,13 @@ export default class GoToView extends SymbolsView {
     });
   }
 
-  populate() {
+  async populate() {
     let editor = atom.workspace.getActiveTextEditor();
     if (!editor) {
       return;
     }
 
-    this.findTag(editor).then(matches => {
+    this.findTag(editor).then(async matches => {
       let tags = [];
       for (let match of Array.from(matches)) {
         let position = this.getTagLine(match);
@@ -57,7 +57,7 @@ export default class GoToView extends SymbolsView {
       if (tags.length === 1) {
         this.openTag(tags[0]);
       } else if (tags.length > 0) {
-        this.setItems(tags);
+        await this.selectListView.update({items: tags});
         this.attach();
       }
     });

--- a/lib/go-to-view.js
+++ b/lib/go-to-view.js
@@ -1,4 +1,4 @@
-'use babel';
+/** @babel */
 
 import path from 'path';
 import SymbolsView from './symbols-view';

--- a/lib/load-tags-handler.js
+++ b/lib/load-tags-handler.js
@@ -1,4 +1,4 @@
-'use babel';
+/** @babel */
 /* global emit*/
 
 import async from 'async';

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,4 @@
-'use babel';
+/** @babel */
 
 export default {
   activate() {

--- a/lib/project-view.js
+++ b/lib/project-view.js
@@ -1,4 +1,4 @@
-'use babel';
+/** @babel */
 
 import { CompositeDisposable, File } from 'atom';
 import humanize from 'humanize-plus';

--- a/lib/project-view.js
+++ b/lib/project-view.js
@@ -7,16 +7,15 @@ import TagReader from './tag-reader';
 import getTagsFile from './get-tags-file';
 
 export default class ProjectView extends SymbolsView {
-  initialize() {
-    super.initialize(...arguments);
+  constructor(stack) {
+    super(stack, 'Project has no tags file or it is empty', 10);
     this.reloadTags = true;
-    this.setMaxItems(10);
   }
 
   destroy() {
     this.stopTask();
     this.unwatchTagsFiles();
-    super.destroy(...arguments);
+    return super.destroy();
   }
 
   toggle() {
@@ -28,17 +27,9 @@ export default class ProjectView extends SymbolsView {
     }
   }
 
-  getEmptyMessage(itemCount) {
-    if (itemCount === 0) {
-      return 'Project has no tags file or it is empty';
-    } else {
-      return super.getEmptyMessage(...arguments);
-    }
-  }
-
-  populate() {
+  async populate() {
     if (this.tags) {
-      this.setItems(this.tags);
+      await this.selectListView.update({items: this.tags});
     }
 
     if (this.reloadTags) {
@@ -46,14 +37,18 @@ export default class ProjectView extends SymbolsView {
       this.startTask();
 
       if (this.tags) {
-        this.setLoading('Reloading project symbols\u2026');
+        await this.selectListView.update({
+          loadingMessage: 'Reloading project symbols\u2026',
+        });
       } else {
-        this.setLoading('Loading project symbols\u2026');
-        this.loadingBadge.text('0');
+        await this.selectListView.update({
+          loadingMessage: 'Loading project symbols\u2026',
+          loadingBadge: 0,
+        });
         let tagsRead = 0;
         this.loadTagsTask.on('tags', tags => {
           tagsRead += tags.length;
-          this.loadingBadge.text(humanize.intComma(tagsRead));
+          this.selectListView.update({loadingBadge: humanize.intComma(tagsRead)});
         });
       }
     }
@@ -71,7 +66,11 @@ export default class ProjectView extends SymbolsView {
     this.loadTagsTask = TagReader.getAllTags(tags => {
       this.tags = tags;
       this.reloadTags = this.tags.length === 0;
-      this.setItems(this.tags);
+      this.selectListView.update({
+        loadingMessage: null,
+        loadingBadge: null,
+        items: this.tags,
+      });
     });
 
     this.watchTagsFiles();

--- a/lib/symbols-view.js
+++ b/lib/symbols-view.js
@@ -2,17 +2,18 @@
 
 import path from 'path';
 import { Point } from 'atom';
-import { $$, SelectListView } from 'atom-space-pen-views';
+import SelectListView from 'atom-select-list';
 import fs from 'fs-plus';
 import { match } from 'fuzzaldrin';
 
-export default class SymbolsView extends SelectListView {
+export default class SymbolsView {
   static highlightMatches(context, name, matches, offsetIndex) {
     if (!offsetIndex) {
       offsetIndex = 0;
     }
     let lastIndex = 0;
     let matchedChars = []; // Build up a set of matched chars to be more semantic
+    const fragment = document.createDocumentFragment();
 
     for (let matchIndex of Array.from(matches)) {
       matchIndex -= offsetIndex;
@@ -22,81 +23,122 @@ export default class SymbolsView extends SelectListView {
       const unmatched = name.substring(lastIndex, matchIndex);
       if (unmatched) {
         if (matchedChars.length) {
-          context.span(matchedChars.join(''), {class: 'character-match'});
+          const span = document.createElement('span');
+          span.classList.add('character-match');
+          span.textContent = matchedChars.join('');
+          fragment.appendChild(span);
         }
         matchedChars = [];
-        context.text(unmatched);
+        fragment.appendChild(document.createTextNode(unmatched));
       }
       matchedChars.push(name[matchIndex]);
       lastIndex = matchIndex + 1;
     }
 
     if (matchedChars.length) {
-      context.span(matchedChars.join(''), {class: 'character-match'});
+      const span = document.createElement('span');
+      span.classList.add('character-match');
+      span.textContent = matchedChars.join('');
+      fragment.appendChild(span);
     }
 
     // Remaining characters are plain text
-    return context.text(name.substring(lastIndex));
+    fragment.appendChild(document.createTextNode(name.substring(lastIndex)));
+
+    return fragment
   }
 
-  initialize(stack) {
+  constructor(stack, emptyMessage = 'No symbols found', maxResults = null) {
     this.stack = stack;
-    super.initialize(...arguments);
+    this.selectListView = new SelectListView({
+      maxResults,
+      emptyMessage,
+      items: [],
+      filterKeyForItem: (item) => item.name,
+      elementForItem: this.elementForItem.bind(this),
+      didChangeSelection: this.didChangeSelection.bind(this),
+      didConfirmSelection: this.didConfirmSelection.bind(this),
+      didConfirmEmptySelection: this.didConfirmEmptySelection.bind(this),
+      didCancelSelection: this.didCancelSelection.bind(this),
+    });
+    this.element = this.selectListView.element;
+    this.element.classList.add('symbols-view');
     this.panel = atom.workspace.addModalPanel({item: this, visible: false});
-    this.addClass('symbols-view');
   }
 
-  destroy() {
-    this.cancel();
+  async destroy() {
+    await this.cancel()
     this.panel.destroy();
+    return this.selectListView.destroy();
   }
 
   getFilterKey() {
     return 'name';
   }
 
-  viewForItem({position, name, file, directory}) {
+  elementForItem({position, name, file, directory}) {
     // Style matched characters in search results
-    const matches = match(name, this.getFilterQuery());
+    const matches = match(name, this.selectListView.getFilterQuery());
 
     if (atom.project.getPaths().length > 1) {
       file = path.join(path.basename(directory), file);
     }
 
-    return $$(function() {
-      return this.li({class: 'two-lines'}, () => {
-        if (position != null) {
-          this.div(`${name}:${position.row + 1}`, {class: 'primary-line'});
-        } else {
-          this.div({class: 'primary-line'}, () => SymbolsView.highlightMatches(this, name, matches));
-        }
-        return this.div(file, {class: 'secondary-line'});
-      });
-    });
+    const li = document.createElement('li');
+    li.classList.add('two-lines');
+
+    const primaryLine = document.createElement('div');
+    primaryLine.classList.add('primary-line');
+    if (position) {
+      primaryLine.textContent = `${name}:${position.row + 1}`;
+    } else {
+      primaryLine.appendChild(SymbolsView.highlightMatches(this, name, matches));
+    }
+    li.appendChild(primaryLine);
+
+    const secondaryLine = document.createElement('div');
+    secondaryLine.classList.add('secondary-line');
+    secondaryLine.textContent = file;
+    li.appendChild(secondaryLine);
+
+    return li;
   }
 
-  getEmptyMessage(itemCount) {
-    if (itemCount === 0) {
-      return 'No symbols found';
-    } else {
-      return super.getEmptyMessage(...arguments);
+  async cancel() {
+    if (!this.isCanceling) {
+      this.isCanceling = true
+      await this.selectListView.update({items: []})
+      this.panel.hide();
+      if (this.previouslyFocusedElement) {
+        this.previouslyFocusedElement.focus()
+        this.previouslyFocusedElement = null
+      }
+      this.isCanceling = false
     }
   }
 
-  cancelled() {
-    this.panel.hide();
+  didCancelSelection() {
+    this.cancel();
   }
 
-  confirmed(tag) {
+  didConfirmEmptySelection() {
+    this.cancel();
+  }
+
+  async didConfirmSelection(tag) {
     if (tag.file && !fs.isFileSync(path.join(tag.directory, tag.file))) {
-      this.setError('Selected file does not exist');
+      await this.selectListView.update({errorMessage: 'Selected file does not exist'});
       setTimeout(() => {
-        this.setError();
+        this.selectListView.update({errorMessage: null})
       }, 2000);
     } else {
-      this.cancel();
+      await this.cancel();
       this.openTag(tag);
     }
+  }
+
+  didChangeSelection(tag) {
+    // no-op
   }
 
   openTag(tag) {
@@ -119,11 +161,11 @@ export default class SymbolsView extends SelectListView {
         }
         return undefined;
       });
-    } else if (position && !(previous.position.isEqual(position))) {
+    } else if (position && previous && !previous.position.isEqual(position)) {
       this.moveToPosition(position);
     }
 
-    return this.stack.push(previous);
+    this.stack.push(previous);
   }
 
   moveToPosition(position, beginningOfLine) {
@@ -141,9 +183,10 @@ export default class SymbolsView extends SelectListView {
   }
 
   attach() {
-    this.storeFocusedElement();
+    this.previouslyFocusedElement = document.activeElement;
     this.panel.show();
-    this.focusFilterEditor();
+    this.selectListView.reset();
+    this.selectListView.focus();
   }
 
   getTagLine(tag) {

--- a/lib/symbols-view.js
+++ b/lib/symbols-view.js
@@ -45,7 +45,7 @@ export default class SymbolsView {
     // Remaining characters are plain text
     fragment.appendChild(document.createTextNode(name.substring(lastIndex)));
 
-    return fragment
+    return fragment;
   }
 
   constructor(stack, emptyMessage = 'No symbols found', maxResults = null) {
@@ -67,7 +67,7 @@ export default class SymbolsView {
   }
 
   async destroy() {
-    await this.cancel()
+    await this.cancel();
     this.panel.destroy();
     return this.selectListView.destroy();
   }
@@ -106,14 +106,14 @@ export default class SymbolsView {
 
   async cancel() {
     if (!this.isCanceling) {
-      this.isCanceling = true
-      await this.selectListView.update({items: []})
+      this.isCanceling = true;
+      await this.selectListView.update({items: []});
       this.panel.hide();
       if (this.previouslyFocusedElement) {
-        this.previouslyFocusedElement.focus()
-        this.previouslyFocusedElement = null
+        this.previouslyFocusedElement.focus();
+        this.previouslyFocusedElement = null;
       }
-      this.isCanceling = false
+      this.isCanceling = false;
     }
   }
 
@@ -129,7 +129,7 @@ export default class SymbolsView {
     if (tag.file && !fs.isFileSync(path.join(tag.directory, tag.file))) {
       await this.selectListView.update({errorMessage: 'Selected file does not exist'});
       setTimeout(() => {
-        this.selectListView.update({errorMessage: null})
+        this.selectListView.update({errorMessage: null});
       }, 2000);
     } else {
       await this.cancel();

--- a/lib/symbols-view.js
+++ b/lib/symbols-view.js
@@ -1,4 +1,4 @@
-'use babel';
+/** @babel */
 
 import path from 'path';
 import { Point } from 'atom';

--- a/lib/tag-generator.js
+++ b/lib/tag-generator.js
@@ -2,6 +2,7 @@
 
 import { BufferedProcess, Point } from 'atom';
 import path from 'path';
+import fs from 'fs-plus';
 
 export default class TagGenerator {
   constructor(path1, scopeName) {
@@ -10,20 +11,16 @@ export default class TagGenerator {
   }
 
   getPackageRoot() {
-    let packageRoot
-    if (typeof snapshotResult === 'undefined') {
-      packageRoot = path.resolve(__dirname, '..');
+    if (fs.isAbsolute(__dirname)) {
+      return path.resolve(__dirname, '..')
     } else {
-      packageRoot = path.resolve(snapshotResult.entryPointDirPath, __dirname, '..')
-    }
-
-    const {resourcePath} = atom.getLoadSettings();
-    if (path.extname(resourcePath) === '.asar') {
-      if (packageRoot.indexOf(resourcePath) === 0) {
-        packageRoot = path.join(`${resourcePath}.unpacked`, 'node_modules', 'symbols-view');
+      const {resourcePath} = atom.getLoadSettings();
+      if (path.extname(resourcePath) === '.asar') {
+        return path.join(`${resourcePath}.unpacked`, 'node_modules', 'symbols-view');
+      } else {
+        return path.join(resourcePath, 'node_modules', 'symbols-view');
       }
     }
-    return packageRoot;
   }
 
   parseTagLine(line) {

--- a/lib/tag-generator.js
+++ b/lib/tag-generator.js
@@ -10,7 +10,13 @@ export default class TagGenerator {
   }
 
   getPackageRoot() {
-    let packageRoot = path.resolve(__dirname, '..');
+    let packageRoot
+    if (typeof snapshotResult === 'undefined') {
+      packageRoot = path.resolve(__dirname, '..');
+    } else {
+      packageRoot = path.resolve(snapshotResult.entryPointDirPath, __dirname, '..')
+    }
+
     const {resourcePath} = atom.getLoadSettings();
     if (path.extname(resourcePath) === '.asar') {
       if (packageRoot.indexOf(resourcePath) === 0) {

--- a/lib/tag-generator.js
+++ b/lib/tag-generator.js
@@ -1,4 +1,4 @@
-'use babel';
+/** @babel */
 
 import { BufferedProcess, Point } from 'atom';
 import path from 'path';

--- a/lib/tag-generator.js
+++ b/lib/tag-generator.js
@@ -12,7 +12,7 @@ export default class TagGenerator {
 
   getPackageRoot() {
     if (fs.isAbsolute(__dirname)) {
-      return path.resolve(__dirname, '..')
+      return path.resolve(__dirname, '..');
     } else {
       const {resourcePath} = atom.getLoadSettings();
       if (path.extname(resourcePath) === '.asar') {

--- a/lib/tag-reader.js
+++ b/lib/tag-reader.js
@@ -1,4 +1,4 @@
-'use babel';
+/** @babel */
 
 import { Task } from 'atom';
 import ctags from 'ctags';

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "async": "^0.2.6",
+    "atom-select-list": "0.0.14",
     "atom-space-pen-views": "^2.2.0",
     "ctags": "^3.0.0",
     "fs-plus": "^2.9.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "async": "^0.2.6",
     "atom-select-list": "0.0.14",
-    "atom-space-pen-views": "^2.2.0",
     "ctags": "^3.0.0",
     "fs-plus": "^2.9.3",
     "fuzzaldrin": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "async": "^0.2.6",
-    "atom-select-list": "0.0.14",
+    "atom-select-list": "0.0.16",
     "ctags": "^3.0.0",
     "fs-plus": "^2.9.3",
     "fuzzaldrin": "^2.1.0",

--- a/spec/async-spec-helpers.js
+++ b/spec/async-spec-helpers.js
@@ -1,0 +1,67 @@
+/** @babel */
+
+export function beforeEach (fn) {
+  global.beforeEach(function () {
+    const result = fn()
+    if (result instanceof Promise) {
+      waitsForPromise(() => result)
+    }
+  })
+}
+
+export function afterEach (fn) {
+  global.afterEach(function () {
+    const result = fn()
+    if (result instanceof Promise) {
+      waitsForPromise(() => result)
+    }
+  })
+}
+
+['it', 'fit', 'ffit', 'fffit'].forEach(function (name) {
+  module.exports[name] = function (description, fn) {
+    global[name](description, function () {
+      const result = fn()
+      if (result instanceof Promise) {
+        waitsForPromise(() => result)
+      }
+    })
+  }
+})
+
+export async function conditionPromise (condition)  {
+  const startTime = Date.now()
+
+  while (true) {
+    await timeoutPromise(100)
+
+    let conditionResult = condition()
+    if (condition instanceof Promise) {
+      conditionResult = await conditionResult
+    }
+
+    if (conditionResult) {
+      return
+    }
+
+    if (Date.now() - startTime > 5000) {
+      throw new Error("Timed out waiting on condition")
+    }
+  }
+}
+
+export function timeoutPromise (timeout) {
+  return new Promise(function (resolve) {
+    global.setTimeout(resolve, timeout)
+  })
+}
+
+function waitsForPromise (fn) {
+  const promise = fn()
+  global.waitsFor('spec promise to resolve', function (done) {
+    promise.then(done, function (error) {
+      jasmine.getEnv().currentSpec.fail(error)
+      done()
+    })
+  })
+}

--- a/spec/async-spec-helpers.js
+++ b/spec/async-spec-helpers.js
@@ -1,67 +1,67 @@
 /** @babel */
 
-export function beforeEach (fn) {
-  global.beforeEach(function () {
-    const result = fn()
+export function beforeEach(fn) {
+  global.beforeEach(function() {
+    const result = fn();
     if (result instanceof Promise) {
-      waitsForPromise(() => result)
+      waitsForPromise(() => result);
     }
-  })
+  });
 }
 
-export function afterEach (fn) {
-  global.afterEach(function () {
-    const result = fn()
+export function afterEach(fn) {
+  global.afterEach(function() {
+    const result = fn();
     if (result instanceof Promise) {
-      waitsForPromise(() => result)
+      waitsForPromise(() => result);
     }
-  })
+  });
 }
 
-['it', 'fit', 'ffit', 'fffit'].forEach(function (name) {
-  module.exports[name] = function (description, fn) {
-    global[name](description, function () {
-      const result = fn()
+['it', 'fit', 'ffit', 'fffit'].forEach(function(name) {
+  module.exports[name] = function(description, fn) {
+    global[name](description, function() {
+      const result = fn();
       if (result instanceof Promise) {
-        waitsForPromise(() => result)
+        waitsForPromise(() => result);
       }
-    })
-  }
-})
+    });
+  };
+});
 
-export async function conditionPromise (condition)  {
-  const startTime = Date.now()
+export async function conditionPromise(condition)  {
+  const startTime = Date.now();
 
   while (true) {
-    await timeoutPromise(100)
+    await timeoutPromise(100);
 
-    let conditionResult = condition()
+    let conditionResult = condition();
     if (condition instanceof Promise) {
-      conditionResult = await conditionResult
+      conditionResult = await conditionResult;
     }
 
     if (conditionResult) {
-      return
+      return;
     }
 
     if (Date.now() - startTime > 5000) {
-      throw new Error("Timed out waiting on condition")
+      throw new Error('Timed out waiting on condition');
     }
   }
 }
 
-export function timeoutPromise (timeout) {
-  return new Promise(function (resolve) {
-    global.setTimeout(resolve, timeout)
-  })
+export function timeoutPromise(timeout) {
+  return new Promise(function(resolve) {
+    global.setTimeout(resolve, timeout);
+  });
 }
 
-function waitsForPromise (fn) {
-  const promise = fn()
-  global.waitsFor('spec promise to resolve', function (done) {
-    promise.then(done, function (error) {
-      jasmine.getEnv().currentSpec.fail(error)
-      done()
-    })
-  })
+function waitsForPromise(fn) {
+  const promise = fn();
+  global.waitsFor('spec promise to resolve', function(done) {
+    promise.then(done, function(error) {
+      jasmine.getEnv().currentSpec.fail(error);
+      done();
+    });
+  });
 }

--- a/spec/symbols-view-spec.js
+++ b/spec/symbols-view-spec.js
@@ -1,4 +1,4 @@
-'use babel';
+/** @babel */
 /* eslint-env jasmine */
 /* global waitsForPromise */
 

--- a/spec/symbols-view-spec.js
+++ b/spec/symbols-view-spec.js
@@ -8,7 +8,7 @@ import temp from 'temp';
 import SymbolsView from '../lib/symbols-view';
 import TagGenerator from '../lib/tag-generator';
 
-import {it, fit, ffit, fffit, beforeEach, afterEach, conditionPromise} from './async-spec-helpers'
+import {it, fit, ffit, fffit, beforeEach, afterEach, conditionPromise} from './async-spec-helpers';
 
 describe('SymbolsView', () => {
   let [symbolsView, activationPromise, editor, directory] = [];
@@ -17,7 +17,7 @@ describe('SymbolsView', () => {
   const getEditorView = () => atom.views.getView(atom.workspace.getActiveTextEditor());
 
   beforeEach(async () => {
-    jasmine.unspy(global, 'setTimeout')
+    jasmine.unspy(global, 'setTimeout');
 
     atom.project.setPaths([
       temp.mkdirSync('other-dir-'),
@@ -37,12 +37,12 @@ describe('SymbolsView', () => {
     });
 
     it('initially displays all JavaScript functions with line numbers', async () => {
-      atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols')
-      await activationPromise
-      symbolsView = atom.workspace.getModalPanels()[0].item
-      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0)
-      expect(symbolsView.selectListView.refs.loadingMessage).toBeUndefined()
-      expect(document.body.contains(symbolsView.element)).toBe(true)
+      atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
+      await activationPromise;
+      symbolsView = atom.workspace.getModalPanels()[0].item;
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
+      expect(symbolsView.selectListView.refs.loadingMessage).toBeUndefined();
+      expect(document.body.contains(symbolsView.element)).toBe(true);
       expect(symbolsView.element.querySelectorAll('li').length).toBe(2);
       expect(symbolsView.element.querySelector('li:first-child .primary-line')).toHaveText('quicksort');
       expect(symbolsView.element.querySelector('li:first-child .secondary-line')).toHaveText('Line 1');
@@ -54,14 +54,14 @@ describe('SymbolsView', () => {
     it('caches tags until the editor changes', async () => {
       editor = atom.workspace.getActiveTextEditor();
       atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
-      await activationPromise
-      symbolsView = atom.workspace.getModalPanels()[0].item
-      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0)
+      await activationPromise;
+      symbolsView = atom.workspace.getModalPanels()[0].item;
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
       await symbolsView.cancel();
 
       spyOn(symbolsView, 'generateTags').andCallThrough();
       atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
-      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0)
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
       expect(symbolsView.selectListView.refs.loadingMessage).toBeUndefined();
       expect(symbolsView.element.querySelectorAll('li').length).toBe(2);
       expect(symbolsView.generateTags).not.toHaveBeenCalled();
@@ -69,7 +69,7 @@ describe('SymbolsView', () => {
 
       editor.save();
       atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
-      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0)
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
       expect(symbolsView.selectListView.refs.loadingMessage).toBeUndefined();
       expect(symbolsView.element.querySelectorAll('li').length).toBe(2);
       expect(symbolsView.generateTags).toHaveBeenCalled();
@@ -80,18 +80,18 @@ describe('SymbolsView', () => {
     it('displays an error when no tags match text in mini-editor', async () => {
       atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
       await activationPromise;
-      symbolsView = atom.workspace.getModalPanels()[0].item
-      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0)
+      symbolsView = atom.workspace.getModalPanels()[0].item;
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
 
       symbolsView.selectListView.refs.queryEditor.setText('nothing will match this');
-      await conditionPromise(() => symbolsView.selectListView.refs.emptyMessage)
+      await conditionPromise(() => symbolsView.selectListView.refs.emptyMessage);
       expect(document.body.contains(symbolsView.element)).toBe(true);
       expect(symbolsView.element.querySelectorAll('li').length).toBe(0);
       expect(symbolsView.selectListView.refs.emptyMessage.textContent.length).toBeGreaterThan(0);
 
       // Should remove error
       symbolsView.selectListView.refs.queryEditor.setText('');
-      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0)
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
       expect(symbolsView.element.querySelectorAll('li').length).toBe(2);
       expect(symbolsView.selectListView.refs.emptyMessage).toBeUndefined();
     });
@@ -100,26 +100,26 @@ describe('SymbolsView', () => {
       expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 0]);
       atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
       await activationPromise;
-      symbolsView = atom.workspace.getModalPanels()[0].item
-      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0)
+      symbolsView = atom.workspace.getModalPanels()[0].item;
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
 
-      symbolsView.element.querySelectorAll('li')[1].click()
+      symbolsView.element.querySelectorAll('li')[1].click();
       expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([1, 2]);
     });
   });
 
   describe("when tags can't be generated for a file", () => {
     beforeEach(async () => {
-      await atom.workspace.open('sample.txt')
+      await atom.workspace.open('sample.txt');
     });
 
     it('shows an error message when no matching tags are found', async () => {
       atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
       await activationPromise;
-      symbolsView = atom.workspace.getModalPanels()[0].item
+      symbolsView = atom.workspace.getModalPanels()[0].item;
 
-      await conditionPromise(() => symbolsView.selectListView.refs.emptyMessage)
-      expect(document.body.contains(symbolsView.element))
+      await conditionPromise(() => symbolsView.selectListView.refs.emptyMessage);
+      expect(document.body.contains(symbolsView.element));
       expect(symbolsView.element.querySelectorAll('li').length).toBe(0);
       expect(symbolsView.selectListView.refs.emptyMessage).toBeVisible();
       expect(symbolsView.selectListView.refs.emptyMessage.textContent.length).toBeGreaterThan(0);
@@ -154,7 +154,7 @@ describe('SymbolsView', () => {
       editor.setCursorBufferPosition([0, 2]);
       atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
 
-      await activationPromise
+      await activationPromise;
 
       expect(editor.getCursorBufferPosition()).toEqual([0, 2]);
     });
@@ -175,7 +175,7 @@ describe('SymbolsView', () => {
       editor = atom.workspace.getActiveTextEditor();
       editor.setCursorBufferPosition([8, 14]);
       atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
-      symbolsView = atom.workspace.getModalPanels()[0].item
+      symbolsView = atom.workspace.getModalPanels()[0].item;
 
       await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
       expect(symbolsView.element.querySelectorAll('li').length).toBe(2);
@@ -183,7 +183,7 @@ describe('SymbolsView', () => {
       spyOn(SymbolsView.prototype, 'moveToPosition').andCallThrough();
       symbolsView.selectListView.confirmSelection();
 
-      await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1)
+      await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
       expect(atom.workspace.getActiveTextEditor().getPath()).toBe(directory.resolve('tagged-duplicate.js'));
       expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 4]);
     });
@@ -199,7 +199,7 @@ describe('SymbolsView', () => {
       atom.workspace.getActiveTextEditor().setCursorBufferPosition([18, 4]);
       atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
 
-      await activationPromise
+      await activationPromise;
       await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
       expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([7, 2]);
       SymbolsView.prototype.moveToPosition.reset();
@@ -286,7 +286,7 @@ describe('SymbolsView', () => {
         editor.setCursorBufferPosition([6, 0]);
         atom.commands.dispatch(getEditorView(), 'symbols-view:return-from-declaration');
 
-        await activationPromise
+        await activationPromise;
         expect(editor.getCursorBufferPosition()).toEqual([6, 0]);
       });
 
@@ -297,7 +297,7 @@ describe('SymbolsView', () => {
         spyOn(SymbolsView.prototype, 'moveToPosition').andCallThrough();
         atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
 
-        await activationPromise
+        await activationPromise;
         await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
         expect(editor.getCursorBufferPosition()).toEqual([2, 0]);
         atom.commands.dispatch(getEditorView(), 'symbols-view:return-from-declaration');
@@ -326,17 +326,17 @@ describe('SymbolsView', () => {
   describe('project symbols', () => {
     it('displays all tags', async () => {
       await atom.workspace.open(directory.resolve('tagged.js'));
-      expect(getWorkspaceView().querySelector('.symbols-view')).toBeNull()
+      expect(getWorkspaceView().querySelector('.symbols-view')).toBeNull();
       atom.commands.dispatch(getWorkspaceView(), 'symbols-view:toggle-project-symbols');
 
-      await activationPromise
-      symbolsView = atom.workspace.getModalPanels()[0].item
+      await activationPromise;
+      symbolsView = atom.workspace.getModalPanels()[0].item;
 
       await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
       const directoryBasename = path.basename(directory.getPath());
       const taggedFile = path.join(directoryBasename, 'tagged.js');
       expect(symbolsView.selectListView.refs.loadingMessage).toBeUndefined();
-      expect(document.body.contains(symbolsView.element)).toBe(true)
+      expect(document.body.contains(symbolsView.element)).toBe(true);
       expect(symbolsView.element.querySelectorAll('li').length).toBe(4);
       expect(symbolsView.element.querySelector('li:first-child .primary-line')).toHaveText('callMeMaybe');
       expect(symbolsView.element.querySelector('li:first-child .secondary-line')).toHaveText(taggedFile);
@@ -357,11 +357,11 @@ describe('SymbolsView', () => {
 
       it("does not include the root directory's name when displaying the tag's filename", async () => {
         await atom.workspace.open(directory.resolve('tagged.js'));
-        expect(getWorkspaceView().querySelector('.symbols-view')).toBeNull()
+        expect(getWorkspaceView().querySelector('.symbols-view')).toBeNull();
         atom.commands.dispatch(getWorkspaceView(), 'symbols-view:toggle-project-symbols');
 
-        await activationPromise
-        symbolsView = atom.workspace.getModalPanels()[0].item
+        await activationPromise;
+        symbolsView = atom.workspace.getModalPanels()[0].item;
         await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
         expect(symbolsView.element.querySelector('li:first-child .primary-line')).toHaveText('callMeMaybe');
         expect(symbolsView.element.querySelector('li:first-child .secondary-line')).toHaveText('tagged.js');
@@ -375,14 +375,14 @@ describe('SymbolsView', () => {
         it("doesn't open the editor", async () => {
           atom.commands.dispatch(getWorkspaceView(), 'symbols-view:toggle-project-symbols');
 
-          await activationPromise
+          await activationPromise;
 
-          symbolsView = atom.workspace.getModalPanels()[0].item
+          symbolsView = atom.workspace.getModalPanels()[0].item;
 
           await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
           spyOn(atom.workspace, 'open').andCallThrough();
           symbolsView.element.querySelector('li:first-child').click();
-          await conditionPromise(() => symbolsView.selectListView.refs.errorMessage)
+          await conditionPromise(() => symbolsView.selectListView.refs.errorMessage);
           expect(atom.workspace.open).not.toHaveBeenCalled();
           expect(symbolsView.selectListView.refs.errorMessage.textContent.length).toBeGreaterThan(0);
         });
@@ -399,16 +399,16 @@ describe('SymbolsView', () => {
       atom.workspace.getActiveTextEditor().setText('var test = function() {}');
       atom.workspace.getActiveTextEditor().save();
       atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
-      await activationPromise
+      await activationPromise;
 
-      symbolsView = atom.workspace.getModalPanels()[0].item
+      symbolsView = atom.workspace.getModalPanels()[0].item;
       await conditionPromise(() => symbolsView.selectListView.refs.emptyMessage);
       atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
 
       atom.workspace.getActiveTextEditor().setGrammar(atom.grammars.grammarForScopeName('source.js'));
       atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
       await conditionPromise(() => symbolsView.element.querySelectorAll('li').length === 1);
-      expect(document.body.contains(symbolsView.element)).toBe(true)
+      expect(document.body.contains(symbolsView.element)).toBe(true);
       expect(symbolsView.element.querySelector('li:first-child .primary-line')).toHaveText('test');
       expect(symbolsView.element.querySelector('li:first-child .secondary-line')).toHaveText('Line 1');
     });
@@ -422,11 +422,11 @@ describe('SymbolsView', () => {
     it('highlights an exact match', async () => {
       atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
 
-      await activationPromise
-      symbolsView = atom.workspace.getModalPanels()[0].item
+      await activationPromise;
+      symbolsView = atom.workspace.getModalPanels()[0].item;
       await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
       symbolsView.selectListView.refs.queryEditor.setText('quicksort');
-      await etch.getScheduler().getNextUpdatePromise()
+      await etch.getScheduler().getNextUpdatePromise();
       const resultView = symbolsView.element.querySelector('.selected');
       const matches = resultView.querySelectorAll('.character-match');
       expect(matches.length).toBe(1);
@@ -435,11 +435,11 @@ describe('SymbolsView', () => {
 
     it('highlights a partial match', async () => {
       atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
-      await activationPromise
-      symbolsView = atom.workspace.getModalPanels()[0].item
+      await activationPromise;
+      symbolsView = atom.workspace.getModalPanels()[0].item;
       await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
       symbolsView.selectListView.refs.queryEditor.setText('quick');
-      await etch.getScheduler().getNextUpdatePromise()
+      await etch.getScheduler().getNextUpdatePromise();
       const resultView = symbolsView.element.querySelector('.selected');
       const matches = resultView.querySelectorAll('.character-match');
       expect(matches.length).toBe(1);
@@ -448,11 +448,11 @@ describe('SymbolsView', () => {
 
     it('highlights multiple matches in the symbol name', async () => {
       atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
-      await activationPromise
-      symbolsView = atom.workspace.getModalPanels()[0].item
+      await activationPromise;
+      symbolsView = atom.workspace.getModalPanels()[0].item;
       await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
       symbolsView.selectListView.refs.queryEditor.setText('quicort');
-      await etch.getScheduler().getNextUpdatePromise()
+      await etch.getScheduler().getNextUpdatePromise();
       const resultView = symbolsView.element.querySelector('.selected');
       const matches = resultView.querySelectorAll('.character-match');
       expect(matches.length).toBe(2);
@@ -469,8 +469,8 @@ describe('SymbolsView', () => {
     it('jumps to the selected function', async () => {
       expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 0]);
       atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
-      await activationPromise
-      symbolsView = atom.workspace.getModalPanels()[0].item
+      await activationPromise;
+      symbolsView = atom.workspace.getModalPanels()[0].item;
       await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
       symbolsView.selectListView.selectNext();
       expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([1, 2]);
@@ -481,8 +481,8 @@ describe('SymbolsView', () => {
       atom.workspace.getActiveTextEditor().setSelectedBufferRanges(bufferRanges);
       atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
 
-      await activationPromise
-      symbolsView = atom.workspace.getModalPanels()[0].item
+      await activationPromise;
+      symbolsView = atom.workspace.getModalPanels()[0].item;
       await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
 
       symbolsView.selectListView.selectNext();
@@ -502,8 +502,8 @@ describe('SymbolsView', () => {
       expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 0]);
       atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
 
-      await activationPromise
-      symbolsView = atom.workspace.getModalPanels()[0].item
+      await activationPromise;
+      symbolsView = atom.workspace.getModalPanels()[0].item;
       await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
       symbolsView.selectListView.selectNext();
       expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 0]);

--- a/spec/symbols-view-spec.js
+++ b/spec/symbols-view-spec.js
@@ -1,13 +1,14 @@
 /** @babel */
 /* eslint-env jasmine */
-/* global waitsForPromise */
 
 import path from 'path';
-import { $ } from 'atom-space-pen-views';
+import etch from 'etch';
 import fs from 'fs-plus';
 import temp from 'temp';
 import SymbolsView from '../lib/symbols-view';
 import TagGenerator from '../lib/tag-generator';
+
+import {it, fit, ffit, fffit, beforeEach, afterEach, conditionPromise} from './async-spec-helpers'
 
 describe('SymbolsView', () => {
   let [symbolsView, activationPromise, editor, directory] = [];
@@ -15,8 +16,8 @@ describe('SymbolsView', () => {
   const getWorkspaceView = () => atom.views.getView(atom.workspace);
   const getEditorView = () => atom.views.getView(atom.workspace.getActiveTextEditor());
 
-  beforeEach(() => {
-    spyOn(SymbolsView.prototype, 'setLoading').andCallThrough();
+  beforeEach(async () => {
+    jasmine.unspy(global, 'setTimeout')
 
     atom.project.setPaths([
       temp.mkdirSync('other-dir-'),
@@ -31,687 +32,481 @@ describe('SymbolsView', () => {
   });
 
   describe('when tags can be generated for a file', () => {
-    beforeEach(() => {
-      waitsForPromise(() => atom.workspace.open(directory.resolve('sample.js')));
+    beforeEach(async () => {
+      await atom.workspace.open(directory.resolve('sample.js'));
     });
 
-    it('initially displays all JavaScript functions with line numbers', () => {
-      runs(() => atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols'));
-
-      waitsForPromise(() => activationPromise);
-
-      runs(() => symbolsView = $(getWorkspaceView()).find('.symbols-view').view());
-
-      waitsFor('loading', () => symbolsView.setLoading.callCount > 1);
-
-      waitsFor(() => symbolsView.list.children('li').length > 0);
-
-      runs(() => {
-        expect(symbolsView.loading).toBeEmpty();
-        expect($(getWorkspaceView()).find('.symbols-view')).toExist();
-        expect(symbolsView.list.children('li').length).toBe(2);
-        expect(symbolsView.list.children('li:first').find('.primary-line')).toHaveText('quicksort');
-        expect(symbolsView.list.children('li:first').find('.secondary-line')).toHaveText('Line 1');
-        expect(symbolsView.list.children('li:last').find('.primary-line')).toHaveText('quicksort.sort');
-        expect(symbolsView.list.children('li:last').find('.secondary-line')).toHaveText('Line 2');
-        expect(symbolsView.error).not.toBeVisible();
-      });
+    it('initially displays all JavaScript functions with line numbers', async () => {
+      atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols')
+      await activationPromise
+      symbolsView = atom.workspace.getModalPanels()[0].item
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0)
+      expect(symbolsView.selectListView.refs.loadingMessage).toBeUndefined()
+      expect(document.body.contains(symbolsView.element)).toBe(true)
+      expect(symbolsView.element.querySelectorAll('li').length).toBe(2);
+      expect(symbolsView.element.querySelector('li:first-child .primary-line')).toHaveText('quicksort');
+      expect(symbolsView.element.querySelector('li:first-child .secondary-line')).toHaveText('Line 1');
+      expect(symbolsView.element.querySelector('li:last-child .primary-line')).toHaveText('quicksort.sort');
+      expect(symbolsView.element.querySelector('li:last-child .secondary-line')).toHaveText('Line 2');
+      expect(symbolsView.selectListView.refs.errorMessage).toBeUndefined();
     });
 
-    it('caches tags until the editor changes', () => {
-      runs(() => {
-        editor = atom.workspace.getActiveTextEditor();
-        atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
-      });
+    it('caches tags until the editor changes', async () => {
+      editor = atom.workspace.getActiveTextEditor();
+      atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
+      await activationPromise
+      symbolsView = atom.workspace.getModalPanels()[0].item
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0)
+      await symbolsView.cancel();
 
-      waitsForPromise(() => activationPromise);
+      spyOn(symbolsView, 'generateTags').andCallThrough();
+      atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0)
+      expect(symbolsView.selectListView.refs.loadingMessage).toBeUndefined();
+      expect(symbolsView.element.querySelectorAll('li').length).toBe(2);
+      expect(symbolsView.generateTags).not.toHaveBeenCalled();
+      await symbolsView.cancel();
 
-      runs(() => symbolsView = $(getWorkspaceView()).find('.symbols-view').view());
-
-      waitsFor(() => symbolsView.list.children('li').length > 0);
-
-      runs(() => {
-        symbolsView.cancel();
-        spyOn(symbolsView, 'generateTags').andCallThrough();
-        atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
-      });
-
-      waitsFor(() => symbolsView.list.children('li').length > 0);
-
-      runs(() => {
-        expect(symbolsView.loading).toBeEmpty();
-        expect(symbolsView.list.children('li').length).toBe(2);
-        expect(symbolsView.generateTags).not.toHaveBeenCalled();
-        editor.save();
-        symbolsView.cancel();
-        atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
-      });
-
-      waitsFor(() => symbolsView.list.children('li').length > 0);
-
-      runs(() => {
-        expect(symbolsView.loading).toBeEmpty();
-        expect(symbolsView.list.children('li').length).toBe(2);
-        expect(symbolsView.generateTags).toHaveBeenCalled();
-        editor.destroy();
-        expect(symbolsView.cachedTags).toEqual({});
-      });
+      editor.save();
+      atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0)
+      expect(symbolsView.selectListView.refs.loadingMessage).toBeUndefined();
+      expect(symbolsView.element.querySelectorAll('li').length).toBe(2);
+      expect(symbolsView.generateTags).toHaveBeenCalled();
+      editor.destroy();
+      expect(symbolsView.cachedTags).toEqual({});
     });
 
-    it('displays an error when no tags match text in mini-editor', () => {
-      runs(() => atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols'));
+    it('displays an error when no tags match text in mini-editor', async () => {
+      atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
+      await activationPromise;
+      symbolsView = atom.workspace.getModalPanels()[0].item
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0)
 
-      waitsForPromise(() => activationPromise);
+      symbolsView.selectListView.refs.queryEditor.setText('nothing will match this');
+      await conditionPromise(() => symbolsView.selectListView.refs.emptyMessage)
+      expect(document.body.contains(symbolsView.element)).toBe(true);
+      expect(symbolsView.element.querySelectorAll('li').length).toBe(0);
+      expect(symbolsView.selectListView.refs.emptyMessage.textContent.length).toBeGreaterThan(0);
 
-      runs(() => symbolsView = $(getWorkspaceView()).find('.symbols-view').view());
-
-      waitsFor(() => symbolsView.list.children('li').length > 0);
-
-      runs(() => {
-        symbolsView.filterEditorView.setText('nothing will match this');
-        window.advanceClock(symbolsView.inputThrottle);
-
-        expect($(getWorkspaceView()).find('.symbols-view')).toExist();
-        expect(symbolsView.list.children('li').length).toBe(0);
-        expect(symbolsView.error).toBeVisible();
-        expect(symbolsView.error.text().length).toBeGreaterThan(0);
-
-        // Should remove error
-        symbolsView.filterEditorView.setText('');
-        window.advanceClock(symbolsView.inputThrottle);
-
-        expect(symbolsView.list.children('li').length).toBe(2);
-        expect(symbolsView.error).not.toBeVisible();
-      });
+      // Should remove error
+      symbolsView.selectListView.refs.queryEditor.setText('');
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0)
+      expect(symbolsView.element.querySelectorAll('li').length).toBe(2);
+      expect(symbolsView.selectListView.refs.emptyMessage).toBeUndefined();
     });
 
-    it('moves the cursor to the selected function', () => {
-      runs(() => {
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 0]);
-        expect($(getWorkspaceView()).find('.symbols-view')).not.toExist();
-        atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
-      });
+    it('moves the cursor to the selected function', async () => {
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 0]);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
+      await activationPromise;
+      symbolsView = atom.workspace.getModalPanels()[0].item
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0)
 
-      waitsFor(() => $(getWorkspaceView()).find('.symbols-view').find('li').length);
-
-      runs(() => {
-        $(getWorkspaceView()).find('.symbols-view').find('li:eq(1)').mousedown().mouseup();
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([1, 2]);
-      });
+      symbolsView.element.querySelectorAll('li')[1].click()
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([1, 2]);
     });
   });
 
   describe("when tags can't be generated for a file", () => {
-    beforeEach(() => {
-      waitsForPromise(() => atom.workspace.open('sample.txt'));
+    beforeEach(async () => {
+      await atom.workspace.open('sample.txt')
     });
 
-    it('shows an error message when no matching tags are found', () => {
-      runs(() => atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols'));
+    it('shows an error message when no matching tags are found', async () => {
+      atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
+      await activationPromise;
+      symbolsView = atom.workspace.getModalPanels()[0].item
 
-      waitsForPromise(() => activationPromise);
-
-      runs(() => symbolsView = $(getWorkspaceView()).find('.symbols-view').view());
-
-      waitsFor(() => symbolsView.error.isVisible());
-
-      runs(() => {
-        expect(symbolsView).toExist();
-        expect(symbolsView.list.children('li').length).toBe(0);
-        expect(symbolsView.error).toBeVisible();
-        expect(symbolsView.error.text().length).toBeGreaterThan(0);
-        expect(symbolsView.loadingArea).not.toBeVisible();
-      });
+      await conditionPromise(() => symbolsView.selectListView.refs.emptyMessage)
+      expect(document.body.contains(symbolsView.element))
+      expect(symbolsView.element.querySelectorAll('li').length).toBe(0);
+      expect(symbolsView.selectListView.refs.emptyMessage).toBeVisible();
+      expect(symbolsView.selectListView.refs.emptyMessage.textContent.length).toBeGreaterThan(0);
+      expect(symbolsView.selectListView.refs.loadingMessage).not.toBeVisible();
     });
   });
 
   describe('TagGenerator', () => {
-    it('generates tags for all JavaScript functions', () => {
+    it('generates tags for all JavaScript functions', async () => {
       let tags = [];
-
-      waitsForPromise(() => {
-        const sampleJsPath = directory.resolve('sample.js');
-        return new TagGenerator(sampleJsPath).generate().then(o => tags = o);
-      });
-
-      runs(() => {
-        expect(tags.length).toBe(2);
-        expect(tags[0].name).toBe('quicksort');
-        expect(tags[0].position.row).toBe(0);
-        expect(tags[1].name).toBe('quicksort.sort');
-        expect(tags[1].position.row).toBe(1);
-      });
+      const sampleJsPath = directory.resolve('sample.js');
+      await new TagGenerator(sampleJsPath).generate().then(o => tags = o);
+      expect(tags.length).toBe(2);
+      expect(tags[0].name).toBe('quicksort');
+      expect(tags[0].position.row).toBe(0);
+      expect(tags[1].name).toBe('quicksort.sort');
+      expect(tags[1].position.row).toBe(1);
     });
 
-    it('generates no tags for text file', () => {
+    it('generates no tags for text file', async () => {
       let tags = [];
-
-      waitsForPromise(() => {
-        const sampleJsPath = directory.resolve('sample.txt');
-        return new TagGenerator(sampleJsPath).generate().then(o => tags = o);
-      });
-
-      runs(() => expect(tags.length).toBe(0));
+      const sampleJsPath = directory.resolve('sample.txt');
+      await new TagGenerator(sampleJsPath).generate().then(o => tags = o);
+      expect(tags.length).toBe(0);
     });
   });
 
   describe('go to declaration', () => {
-    it("doesn't move the cursor when no declaration is found", () => {
-      waitsForPromise(() => atom.workspace.open(directory.resolve('tagged.js')));
+    it("doesn't move the cursor when no declaration is found", async () => {
+      await atom.workspace.open(directory.resolve('tagged.js'));
+      editor = atom.workspace.getActiveTextEditor();
+      editor.setCursorBufferPosition([0, 2]);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
 
-      runs(() => {
-        editor = atom.workspace.getActiveTextEditor();
-        editor.setCursorBufferPosition([0, 2]);
-        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
-      });
+      await activationPromise
 
-      waitsForPromise(() => activationPromise);
-
-      runs(() => expect(editor.getCursorBufferPosition()).toEqual([0, 2]));
+      expect(editor.getCursorBufferPosition()).toEqual([0, 2]);
     });
 
-    it('moves the cursor to the declaration when there is a single matching declaration', () => {
-      waitsForPromise(() => atom.workspace.open(directory.resolve('tagged.js')));
+    it('moves the cursor to the declaration when there is a single matching declaration', async () => {
+      await atom.workspace.open(directory.resolve('tagged.js'));
+      editor = atom.workspace.getActiveTextEditor();
+      editor.setCursorBufferPosition([6, 24]);
+      spyOn(SymbolsView.prototype, 'moveToPosition').andCallThrough();
+      atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
 
-      runs(() => {
+      await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
+      expect(editor.getCursorBufferPosition()).toEqual([2, 0]);
+    });
+
+    it('displays matches when more than one exists and opens the selected match', async () => {
+      await atom.workspace.open(directory.resolve('tagged.js'));
+      editor = atom.workspace.getActiveTextEditor();
+      editor.setCursorBufferPosition([8, 14]);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
+      symbolsView = atom.workspace.getModalPanels()[0].item
+
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
+      expect(symbolsView.element.querySelectorAll('li').length).toBe(2);
+      expect(symbolsView.element).toBeVisible();
+      spyOn(SymbolsView.prototype, 'moveToPosition').andCallThrough();
+      symbolsView.selectListView.confirmSelection();
+
+      await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1)
+      expect(atom.workspace.getActiveTextEditor().getPath()).toBe(directory.resolve('tagged-duplicate.js'));
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 4]);
+    });
+
+    it('includes ? and ! characters in ruby symbols', async () => {
+      atom.project.setPaths([temp.mkdirSync('atom-symbols-view-ruby-')]);
+      fs.copySync(path.join(__dirname, 'fixtures', 'ruby'), atom.project.getPaths()[0]);
+
+      await atom.packages.activatePackage('language-ruby');
+      await atom.workspace.open('file1.rb');
+
+      spyOn(SymbolsView.prototype, 'moveToPosition').andCallThrough();
+      atom.workspace.getActiveTextEditor().setCursorBufferPosition([18, 4]);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
+
+      await activationPromise
+      await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([7, 2]);
+      SymbolsView.prototype.moveToPosition.reset();
+      atom.workspace.getActiveTextEditor().setCursorBufferPosition([19, 2]);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
+
+      await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([11, 2]);
+      SymbolsView.prototype.moveToPosition.reset();
+      atom.workspace.getActiveTextEditor().setCursorBufferPosition([20, 5]);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
+
+      await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([3, 2]);
+      SymbolsView.prototype.moveToPosition.reset();
+      atom.workspace.getActiveTextEditor().setCursorBufferPosition([21, 7]);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
+
+      await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([3, 2]);
+    });
+
+    it('handles jumping to assignment ruby method definitions', async () => {
+      atom.project.setPaths([temp.mkdirSync('atom-symbols-view-ruby-')]);
+      fs.copySync(path.join(__dirname, 'fixtures', 'ruby'), atom.project.getPaths()[0]);
+
+      await atom.packages.activatePackage('language-ruby');
+      await atom.workspace.open('file1.rb');
+      spyOn(SymbolsView.prototype, 'moveToPosition').andCallThrough();
+      atom.workspace.getActiveTextEditor().setCursorBufferPosition([22, 5]);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
+
+      await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([14, 2]);
+      SymbolsView.prototype.moveToPosition.reset();
+      atom.workspace.getActiveTextEditor().setCursorBufferPosition([23, 5]);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
+
+      await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([14, 2]);
+      SymbolsView.prototype.moveToPosition.reset();
+      atom.workspace.getActiveTextEditor().setCursorBufferPosition([24, 5]);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
+
+      await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 0]);
+      SymbolsView.prototype.moveToPosition.reset();
+      atom.workspace.getActiveTextEditor().setCursorBufferPosition([25, 5]);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
+
+      await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([11, 2]);
+    });
+
+    it('handles jumping to fully qualified ruby constant definitions', async () => {
+      atom.project.setPaths([temp.mkdirSync('atom-symbols-view-ruby-')]);
+      fs.copySync(path.join(__dirname, 'fixtures', 'ruby'), atom.project.getPaths()[0]);
+      await atom.packages.activatePackage('language-ruby');
+      await atom.workspace.open('file1.rb');
+      spyOn(SymbolsView.prototype, 'moveToPosition').andCallThrough();
+      atom.workspace.getActiveTextEditor().setCursorBufferPosition([26, 10]);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
+
+      await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([1, 2]);
+      SymbolsView.prototype.moveToPosition.reset();
+      atom.workspace.getActiveTextEditor().setCursorBufferPosition([27, 5]);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
+
+      await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 0]);
+      SymbolsView.prototype.moveToPosition.reset();
+      atom.workspace.getActiveTextEditor().setCursorBufferPosition([28, 5]);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
+
+      await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([31, 0]);
+    });
+
+    describe('return from declaration', () => {
+      it("doesn't do anything when no go-to have been triggered", async () => {
+        await atom.workspace.open(directory.resolve('tagged.js'));
+        editor = atom.workspace.getActiveTextEditor();
+        editor.setCursorBufferPosition([6, 0]);
+        atom.commands.dispatch(getEditorView(), 'symbols-view:return-from-declaration');
+
+        await activationPromise
+        expect(editor.getCursorBufferPosition()).toEqual([6, 0]);
+      });
+
+      it('returns to previous row and column', async () => {
+        await atom.workspace.open(directory.resolve('tagged.js'));
         editor = atom.workspace.getActiveTextEditor();
         editor.setCursorBufferPosition([6, 24]);
         spyOn(SymbolsView.prototype, 'moveToPosition').andCallThrough();
         atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
-      });
 
-      waitsFor(() => SymbolsView.prototype.moveToPosition.callCount === 1);
+        await activationPromise
+        await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
+        expect(editor.getCursorBufferPosition()).toEqual([2, 0]);
+        atom.commands.dispatch(getEditorView(), 'symbols-view:return-from-declaration');
 
-      runs(() => expect(editor.getCursorBufferPosition()).toEqual([2, 0]));
-    });
-
-    it('displays matches when more than one exists and opens the selected match', () => {
-      waitsForPromise(() => atom.workspace.open(directory.resolve('tagged.js')));
-
-      runs(() => {
-        editor = atom.workspace.getActiveTextEditor();
-        editor.setCursorBufferPosition([8, 14]);
-        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
-      });
-
-      waitsFor(() => $(getWorkspaceView()).find('.symbols-view').find('li').length > 0);
-
-      runs(() => {
-        symbolsView = $(getWorkspaceView()).find('.symbols-view').view();
-        expect(symbolsView.list.children('li').length).toBe(2);
-        expect(symbolsView).toBeVisible();
-        spyOn(SymbolsView.prototype, 'moveToPosition').andCallThrough();
-        symbolsView.confirmed(symbolsView.items[0]);
-      });
-
-      waitsFor(() => SymbolsView.prototype.moveToPosition.callCount === 1);
-
-      runs(() => {
-        expect(atom.workspace.getActiveTextEditor().getPath()).toBe(directory.resolve('tagged-duplicate.js'));
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 4]);
-      });
-    });
-
-    it('includes ? and ! characters in ruby symbols', () => {
-      atom.project.setPaths([temp.mkdirSync('atom-symbols-view-ruby-')]);
-      fs.copySync(path.join(__dirname, 'fixtures', 'ruby'), atom.project.getPaths()[0]);
-
-      waitsForPromise(() => atom.packages.activatePackage('language-ruby'));
-
-      waitsForPromise(() => atom.workspace.open('file1.rb'));
-
-      runs(() => {
-        spyOn(SymbolsView.prototype, 'moveToPosition').andCallThrough();
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([18, 4]);
-        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
-      });
-
-      waitsForPromise(() => activationPromise);
-
-      waitsFor(() => SymbolsView.prototype.moveToPosition.callCount === 1);
-
-      runs(() => {
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([7, 2]);
-        SymbolsView.prototype.moveToPosition.reset();
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([19, 2]);
-        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
-      });
-
-      waitsFor(() => SymbolsView.prototype.moveToPosition.callCount === 1);
-
-      runs(() => {
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([11, 2]);
-        SymbolsView.prototype.moveToPosition.reset();
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([20, 5]);
-        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
-      });
-
-      waitsFor(() => SymbolsView.prototype.moveToPosition.callCount === 1);
-
-      runs(() => {
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([3, 2]);
-        SymbolsView.prototype.moveToPosition.reset();
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([21, 7]);
-        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
-      });
-
-      waitsFor(() => SymbolsView.prototype.moveToPosition.callCount === 1);
-
-      runs(() => expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([3, 2]));
-    });
-
-    it('handles jumping to assignment ruby method definitions', () => {
-      atom.project.setPaths([temp.mkdirSync('atom-symbols-view-ruby-')]);
-      fs.copySync(path.join(__dirname, 'fixtures', 'ruby'), atom.project.getPaths()[0]);
-
-      waitsForPromise(() => atom.packages.activatePackage('language-ruby'));
-
-      waitsForPromise(() => atom.workspace.open('file1.rb'));
-
-      runs(() => {
-        spyOn(SymbolsView.prototype, 'moveToPosition').andCallThrough();
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([22, 5]);
-        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
-      });
-
-      waitsFor(() => SymbolsView.prototype.moveToPosition.callCount === 1);
-
-      runs(() => {
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([14, 2]);
-        SymbolsView.prototype.moveToPosition.reset();
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([23, 5]);
-        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
-      });
-
-      waitsFor(() => SymbolsView.prototype.moveToPosition.callCount === 1);
-
-      runs(() => {
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([14, 2]);
-        SymbolsView.prototype.moveToPosition.reset();
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([24, 5]);
-        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
-      });
-
-      waitsFor(() => SymbolsView.prototype.moveToPosition.callCount === 1);
-
-      runs(() => {
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 0]);
-        SymbolsView.prototype.moveToPosition.reset();
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([25, 5]);
-        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
-      });
-
-      waitsFor(() => SymbolsView.prototype.moveToPosition.callCount === 1);
-
-      runs(() => expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([11, 2]));
-    });
-
-    it('handles jumping to fully qualified ruby constant definitions', () => {
-      atom.project.setPaths([temp.mkdirSync('atom-symbols-view-ruby-')]);
-      fs.copySync(path.join(__dirname, 'fixtures', 'ruby'), atom.project.getPaths()[0]);
-
-      waitsForPromise(() => atom.packages.activatePackage('language-ruby'));
-
-      waitsForPromise(() => atom.workspace.open('file1.rb'));
-
-      runs(() => {
-        spyOn(SymbolsView.prototype, 'moveToPosition').andCallThrough();
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([26, 10]);
-        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
-      });
-
-      waitsFor(() => SymbolsView.prototype.moveToPosition.callCount === 1);
-
-      runs(() => {
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([1, 2]);
-        SymbolsView.prototype.moveToPosition.reset();
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([27, 5]);
-        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
-      });
-
-      waitsFor(() => SymbolsView.prototype.moveToPosition.callCount === 1);
-
-      runs(() => {
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 0]);
-        SymbolsView.prototype.moveToPosition.reset();
-        atom.workspace.getActiveTextEditor().setCursorBufferPosition([28, 5]);
-        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
-      });
-
-      waitsFor(() => SymbolsView.prototype.moveToPosition.callCount === 1);
-
-      runs(() => expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([31, 0]));
-    });
-
-    describe('return from declaration', () => {
-      it("doesn't do anything when no go-to have been triggered", () => {
-        waitsForPromise(() => atom.workspace.open(directory.resolve('tagged.js')));
-
-        runs(() => {
-          editor = atom.workspace.getActiveTextEditor();
-          editor.setCursorBufferPosition([6, 0]);
-          atom.commands.dispatch(getEditorView(), 'symbols-view:return-from-declaration');
-        });
-
-        waitsForPromise(() => activationPromise);
-
-        runs(() => expect(editor.getCursorBufferPosition()).toEqual([6, 0]));
-      });
-
-      it('returns to previous row and column', () => {
-        waitsForPromise(() => atom.workspace.open(directory.resolve('tagged.js')));
-
-        runs(() => {
-          editor = atom.workspace.getActiveTextEditor();
-          editor.setCursorBufferPosition([6, 24]);
-          spyOn(SymbolsView.prototype, 'moveToPosition').andCallThrough();
-          atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
-        });
-
-        waitsForPromise(() => activationPromise);
-
-        waitsFor(() => SymbolsView.prototype.moveToPosition.callCount === 1);
-
-        runs(() => {
-          expect(editor.getCursorBufferPosition()).toEqual([2, 0]);
-          atom.commands.dispatch(getEditorView(), 'symbols-view:return-from-declaration');
-        });
-
-        waitsFor(() => SymbolsView.prototype.moveToPosition.callCount === 2);
-
-        runs(() => expect(editor.getCursorBufferPosition()).toEqual([6, 24]));
+        await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 2);
+        expect(editor.getCursorBufferPosition()).toEqual([6, 24]);
       });
     });
 
     describe("when the tag is in a file that doesn't exist", () => {
-      it("doesn't display the tag", () => {
+      it("doesn't display the tag", async () => {
         fs.removeSync(directory.resolve('tagged-duplicate.js'));
+        await atom.workspace.open(directory.resolve('tagged.js'));
 
-        waitsForPromise(() => atom.workspace.open(directory.resolve('tagged.js')));
+        editor = atom.workspace.getActiveTextEditor();
+        editor.setCursorBufferPosition([8, 14]);
+        spyOn(SymbolsView.prototype, 'moveToPosition').andCallThrough();
+        atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
 
-        runs(() => {
-          editor = atom.workspace.getActiveTextEditor();
-          editor.setCursorBufferPosition([8, 14]);
-          spyOn(SymbolsView.prototype, 'moveToPosition').andCallThrough();
-          atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
-        });
-
-        waitsFor(() => SymbolsView.prototype.moveToPosition.callCount === 1);
-
-        runs(() => expect(editor.getCursorBufferPosition()).toEqual([8, 0]));
+        await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
+        expect(editor.getCursorBufferPosition()).toEqual([8, 0]);
       });
     });
   });
 
   describe('project symbols', () => {
-    it('displays all tags', () => {
-      jasmine.unspy(window, 'setTimeout');
+    it('displays all tags', async () => {
+      await atom.workspace.open(directory.resolve('tagged.js'));
+      expect(getWorkspaceView().querySelector('.symbols-view')).toBeNull()
+      atom.commands.dispatch(getWorkspaceView(), 'symbols-view:toggle-project-symbols');
 
-      waitsForPromise(() => atom.workspace.open(directory.resolve('tagged.js')));
+      await activationPromise
+      symbolsView = atom.workspace.getModalPanels()[0].item
 
-      runs(() => {
-        expect($(getWorkspaceView()).find('.symbols-view')).not.toExist();
-        atom.commands.dispatch(getWorkspaceView(), 'symbols-view:toggle-project-symbols');
-      });
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
+      const directoryBasename = path.basename(directory.getPath());
+      const taggedFile = path.join(directoryBasename, 'tagged.js');
+      expect(symbolsView.selectListView.refs.loadingMessage).toBeUndefined();
+      expect(document.body.contains(symbolsView.element)).toBe(true)
+      expect(symbolsView.element.querySelectorAll('li').length).toBe(4);
+      expect(symbolsView.element.querySelector('li:first-child .primary-line')).toHaveText('callMeMaybe');
+      expect(symbolsView.element.querySelector('li:first-child .secondary-line')).toHaveText(taggedFile);
+      expect(symbolsView.element.querySelector('li:last-child .primary-line')).toHaveText('thisIsCrazy');
+      expect(symbolsView.element.querySelector('li:last-child .secondary-line')).toHaveText(taggedFile);
+      atom.commands.dispatch(getWorkspaceView(), 'symbols-view:toggle-project-symbols');
+      fs.removeSync(directory.resolve('tags'));
 
-      waitsForPromise(() => activationPromise);
+      await conditionPromise(() => symbolsView.reloadTags);
+      atom.commands.dispatch(getWorkspaceView(), 'symbols-view:toggle-project-symbols');
 
-      runs(() => symbolsView = $(getWorkspaceView()).find('.symbols-view').view());
-
-      waitsFor('loading', () => symbolsView.setLoading.callCount > 1);
-
-      waitsFor(() => symbolsView.list.children('li').length > 0);
-
-      runs(() => {
-        const directoryBasename = path.basename(directory.getPath());
-        const taggedFile = path.join(directoryBasename, 'tagged.js');
-        expect(symbolsView.loading).toBeEmpty();
-        expect($(getWorkspaceView()).find('.symbols-view')).toExist();
-        expect(symbolsView.list.children('li').length).toBe(4);
-        expect(symbolsView.list.children('li:first').find('.primary-line')).toHaveText('callMeMaybe');
-        expect(symbolsView.list.children('li:first').find('.secondary-line')).toHaveText(taggedFile);
-        expect(symbolsView.list.children('li:last').find('.primary-line')).toHaveText('thisIsCrazy');
-        expect(symbolsView.list.children('li:last').find('.secondary-line')).toHaveText(taggedFile);
-        expect(symbolsView.error).not.toBeVisible();
-        atom.commands.dispatch(getWorkspaceView(), 'symbols-view:toggle-project-symbols');
-
-        fs.removeSync(directory.resolve('tags'));
-      });
-
-      waitsFor(() => symbolsView.reloadTags);
-
-      runs(() => atom.commands.dispatch(getWorkspaceView(), 'symbols-view:toggle-project-symbols'));
-
-      waitsFor(() => symbolsView.error.text().length > 0);
-
-      runs(() => expect(symbolsView.list.children('li').length).toBe(0));
+      await conditionPromise(() => symbolsView.selectListView.refs.loadingMessage);
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length === 0);
     });
 
     describe('when there is only one project', () => {
-      beforeEach(() => atom.project.setPaths([directory.getPath()]));
+      beforeEach(async () => atom.project.setPaths([directory.getPath()]));
 
-      it("does not include the root directory's name when displaying the tag's filename", () => {
-        jasmine.unspy(window, 'setTimeout');
+      it("does not include the root directory's name when displaying the tag's filename", async () => {
+        await atom.workspace.open(directory.resolve('tagged.js'));
+        expect(getWorkspaceView().querySelector('.symbols-view')).toBeNull()
+        atom.commands.dispatch(getWorkspaceView(), 'symbols-view:toggle-project-symbols');
 
-        waitsForPromise(() => atom.workspace.open(directory.resolve('tagged.js')));
-
-        runs(() => {
-          expect($(getWorkspaceView()).find('.symbols-view')).not.toExist();
-          atom.commands.dispatch(getWorkspaceView(), 'symbols-view:toggle-project-symbols');
-        });
-
-        waitsForPromise(() => activationPromise);
-
-        runs(() => symbolsView = $(getWorkspaceView()).find('.symbols-view').view());
-
-        waitsFor(() => symbolsView.list.children('li').length > 0);
-
-        runs(() => {
-          expect(symbolsView.list.children('li:first').find('.primary-line')).toHaveText('callMeMaybe');
-          expect(symbolsView.list.children('li:first').find('.secondary-line')).toHaveText('tagged.js');
-        });
+        await activationPromise
+        symbolsView = atom.workspace.getModalPanels()[0].item
+        await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
+        expect(symbolsView.element.querySelector('li:first-child .primary-line')).toHaveText('callMeMaybe');
+        expect(symbolsView.element.querySelector('li:first-child .secondary-line')).toHaveText('tagged.js');
       });
     });
 
     describe('when selecting a tag', () => {
       describe("when the file doesn't exist", () => {
-        beforeEach(() => fs.removeSync(directory.resolve('tagged.js')));
+        beforeEach(async () => fs.removeSync(directory.resolve('tagged.js')));
 
-        it("doesn't open the editor", () => {
+        it("doesn't open the editor", async () => {
           atom.commands.dispatch(getWorkspaceView(), 'symbols-view:toggle-project-symbols');
 
-          waitsForPromise(() => activationPromise);
+          await activationPromise
 
-          runs(() => symbolsView = $(getWorkspaceView()).find('.symbols-view').view());
+          symbolsView = atom.workspace.getModalPanels()[0].item
 
-          waitsFor(() => symbolsView.list.children('li').length > 0);
-
-          runs(() => {
-            spyOn(atom.workspace, 'open').andCallThrough();
-            symbolsView.list.children('li:first').mousedown().mouseup();
-            expect(atom.workspace.open).not.toHaveBeenCalled();
-            expect(symbolsView.error.text().length).toBeGreaterThan(0);
-          });
+          await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
+          spyOn(atom.workspace, 'open').andCallThrough();
+          symbolsView.element.querySelector('li:first-child').click();
+          await conditionPromise(() => symbolsView.selectListView.refs.errorMessage)
+          expect(atom.workspace.open).not.toHaveBeenCalled();
+          expect(symbolsView.selectListView.refs.errorMessage.textContent.length).toBeGreaterThan(0);
         });
       });
     });
   });
 
   describe('when useEditorGrammarAsCtagsLanguage is set to true', () => {
-    it("uses the language associated with the editor's grammar", () => {
+    it("uses the language associated with the editor's grammar", async () => {
       atom.config.set('symbols-view.useEditorGrammarAsCtagsLanguage', true);
 
-      waitsForPromise(() => atom.packages.activatePackage('language-javascript'));
+      await atom.packages.activatePackage('language-javascript');
+      await atom.workspace.open('sample.javascript');
+      atom.workspace.getActiveTextEditor().setText('var test = function() {}');
+      atom.workspace.getActiveTextEditor().save();
+      atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
+      await activationPromise
 
-      waitsForPromise(() => atom.workspace.open('sample.javascript'));
+      symbolsView = atom.workspace.getModalPanels()[0].item
+      await conditionPromise(() => symbolsView.selectListView.refs.emptyMessage);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
 
-      runs(() => {
-        atom.workspace.getActiveTextEditor().setText('var test = function() {}');
-        atom.workspace.getActiveTextEditor().save();
-        atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
-      });
-
-      waitsForPromise(() => activationPromise);
-
-      waitsFor(() => $(getWorkspaceView()).find('.symbols-view').view().error.isVisible());
-
-      runs(() => {
-        atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
-        atom.workspace.getActiveTextEditor().setGrammar(atom.grammars.grammarForScopeName('source.js'));
-        symbolsView.setLoading.reset();
-        atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
-        symbolsView = $(getWorkspaceView()).find('.symbols-view').view();
-      });
-
-      waitsFor('loading', () => symbolsView.setLoading.callCount > 1);
-
-      waitsFor(() => symbolsView.list.children('li').length === 1);
-
-      runs(() => {
-        expect(symbolsView.loading).toBeEmpty();
-        expect($(getWorkspaceView()).find('.symbols-view')).toExist();
-        expect(symbolsView.list.children('li:first').find('.primary-line')).toHaveText('test');
-        expect(symbolsView.list.children('li:first').find('.secondary-line')).toHaveText('Line 1');
-      });
+      atom.workspace.getActiveTextEditor().setGrammar(atom.grammars.grammarForScopeName('source.js'));
+      atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length === 1);
+      expect(document.body.contains(symbolsView.element)).toBe(true)
+      expect(symbolsView.element.querySelector('li:first-child .primary-line')).toHaveText('test');
+      expect(symbolsView.element.querySelector('li:first-child .secondary-line')).toHaveText('Line 1');
     });
   });
 
   describe('match highlighting', () => {
-    beforeEach(() => {
-      waitsForPromise(() => atom.workspace.open(directory.resolve('sample.js')));
+    beforeEach(async () => {
+      await atom.workspace.open(directory.resolve('sample.js'));
     });
 
-    it('highlights an exact match', () => {
-      runs(() => atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols'));
+    it('highlights an exact match', async () => {
+      atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
 
-      waitsForPromise(() => activationPromise);
-
-      runs(() => symbolsView = $(getWorkspaceView()).find('.symbols-view').view());
-
-      waitsFor(() => symbolsView.list.children('li').length > 0);
-
-      runs(() => {
-        symbolsView.filterEditorView.getModel().setText('quicksort');
-        expect(symbolsView.filterEditorView.getModel().getText()).toBe('quicksort');
-        symbolsView.populateList();
-        const resultView = symbolsView.getSelectedItemView();
-
-        const matches = resultView.find('.character-match');
-        expect(matches.length).toBe(1);
-        expect(matches.last().text()).toBe('quicksort');
-      });
+      await activationPromise
+      symbolsView = atom.workspace.getModalPanels()[0].item
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
+      symbolsView.selectListView.refs.queryEditor.setText('quicksort');
+      await etch.getScheduler().getNextUpdatePromise()
+      const resultView = symbolsView.element.querySelector('.selected');
+      const matches = resultView.querySelectorAll('.character-match');
+      expect(matches.length).toBe(1);
+      expect(matches[0].textContent).toBe('quicksort');
     });
 
-    it('highlights a partial match', () => {
-      runs(() => atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols'));
-
-      waitsForPromise(() => activationPromise);
-
-      runs(() => symbolsView = $(getWorkspaceView()).find('.symbols-view').view());
-
-      waitsFor(() => symbolsView.list.children('li').length > 0);
-
-      runs(() => {
-        symbolsView.filterEditorView.getModel().setText('quick');
-        symbolsView.populateList();
-        const resultView = symbolsView.getSelectedItemView();
-
-        const matches = resultView.find('.character-match');
-        expect(matches.length).toBe(1);
-        expect(matches.last().text()).toBe('quick');
-      });
+    it('highlights a partial match', async () => {
+      atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
+      await activationPromise
+      symbolsView = atom.workspace.getModalPanels()[0].item
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
+      symbolsView.selectListView.refs.queryEditor.setText('quick');
+      await etch.getScheduler().getNextUpdatePromise()
+      const resultView = symbolsView.element.querySelector('.selected');
+      const matches = resultView.querySelectorAll('.character-match');
+      expect(matches.length).toBe(1);
+      expect(matches[0].textContent).toBe('quick');
     });
 
-    it('highlights multiple matches in the symbol name', () => {
-      runs(() => atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols'));
-
-      waitsForPromise(() => activationPromise);
-
-      runs(() => symbolsView = $(getWorkspaceView()).find('.symbols-view').view());
-
-      waitsFor(() => symbolsView.list.children('li').length > 0);
-
-      runs(() => {
-        symbolsView.filterEditorView.getModel().setText('quicort');
-        symbolsView.populateList();
-        const resultView = symbolsView.getSelectedItemView();
-
-        const matches = resultView.find('.character-match');
-        expect(matches.length).toBe(2);
-        expect(matches.first().text()).toBe('quic');
-        expect(matches.last().text()).toBe('ort');
-      });
+    it('highlights multiple matches in the symbol name', async () => {
+      atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
+      await activationPromise
+      symbolsView = atom.workspace.getModalPanels()[0].item
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
+      symbolsView.selectListView.refs.queryEditor.setText('quicort');
+      await etch.getScheduler().getNextUpdatePromise()
+      const resultView = symbolsView.element.querySelector('.selected');
+      const matches = resultView.querySelectorAll('.character-match');
+      expect(matches.length).toBe(2);
+      expect(matches[0].textContent).toBe('quic');
+      expect(matches[1].textContent).toBe('ort');
     });
   });
 
   describe('quickjump to symbol', () => {
-    beforeEach(() => {
-      waitsForPromise(() => atom.workspace.open(directory.resolve('sample.js')));
+    beforeEach(async () => {
+      await atom.workspace.open(directory.resolve('sample.js'));
     });
 
-    it('jumps to the selected function', () => {
-      runs(() => {
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 0]);
-        atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
-      });
-
-      waitsForPromise(() => activationPromise);
-
-      runs(() => symbolsView = $(getWorkspaceView()).find('.symbols-view').view());
-
-      waitsFor(() => symbolsView.list.children('li').length > 0);
-
-      runs(() => {
-        symbolsView.selectNextItemView();
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([1, 2]);
-      });
+    it('jumps to the selected function', async () => {
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 0]);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
+      await activationPromise
+      symbolsView = atom.workspace.getModalPanels()[0].item
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
+      symbolsView.selectListView.selectNext();
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([1, 2]);
     });
 
-    it('restores previous editor state on cancel', () => {
+    it('restores previous editor state on cancel', async () => {
       const bufferRanges = [{start: {row: 0, column: 0}, end: {row: 0, column: 3}}];
+      atom.workspace.getActiveTextEditor().setSelectedBufferRanges(bufferRanges);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
 
-      runs(() => {
-        atom.workspace.getActiveTextEditor().setSelectedBufferRanges(bufferRanges);
-        atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
-      });
+      await activationPromise
+      symbolsView = atom.workspace.getModalPanels()[0].item
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
 
-      waitsForPromise(() => activationPromise);
-
-      runs(() => symbolsView = $(getWorkspaceView()).find('.symbols-view').view());
-
-      waitsFor(() => symbolsView.list.children('li').length > 0);
-
-      runs(() => {
-        symbolsView.selectNextItemView();
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([1, 2]);
-        symbolsView.cancel();
-        expect(atom.workspace.getActiveTextEditor().getSelectedBufferRanges()).toEqual(bufferRanges);
-      });
+      symbolsView.selectListView.selectNext();
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([1, 2]);
+      await symbolsView.cancel();
+      expect(atom.workspace.getActiveTextEditor().getSelectedBufferRanges()).toEqual(bufferRanges);
     });
   });
 
-  describe('when quickJumpToSymbol is set to false', () => {
-    beforeEach(() => {
+  describe('when quickJumpToSymbol is set to false', async () => {
+    beforeEach(async () => {
       atom.config.set('symbols-view.quickJumpToFileSymbol', false);
-      waitsForPromise(() => atom.workspace.open(directory.resolve('sample.js')));
+      await atom.workspace.open(directory.resolve('sample.js'));
     });
 
-    it("won't jumps to the selected function", () => {
-      runs(() => {
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 0]);
-        atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
-      });
+    it("won't jumps to the selected function", async () => {
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 0]);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
 
-      waitsForPromise(() => activationPromise);
-
-      runs(() => symbolsView = $(getWorkspaceView()).find('.symbols-view').view());
-
-      waitsFor(() => symbolsView.list.children('li').length > 0);
-
-      runs(() => {
-        symbolsView.selectNextItemView();
-        expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 0]);
-      });
+      await activationPromise
+      symbolsView = atom.workspace.getModalPanels()[0].item
+      await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
+      symbolsView.selectListView.selectNext();
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([0, 0]);
     });
   });
 });


### PR DESCRIPTION
This pull request uses atom-select-list as a drop-in replacement for atom-space-pen-views. Feature-wise nothing should change, but this will help remove jQuery from Atom.

/cc: @ungb for 👀 