### PR TITLE
Filters symbols based on selected text

### DIFF
--- a/lib/file-view.js
+++ b/lib/file-view.js
@@ -76,8 +76,10 @@ export default class FileView extends SymbolsView {
       if (atom.config.get('symbols-view.quickJumpToFileSymbol') && editor) {
         this.initialState = this.serializeEditorState(editor);
       }
+
+      let selectedText = this.getSelectedText();
       this.populate(filePath);
-      this.attach();
+      this.attach({query: selectedText});
     }
   }
 
@@ -96,10 +98,6 @@ export default class FileView extends SymbolsView {
 
     editor.setSelectedBufferRanges(bufferRanges);
     editorElement.setScrollTop(scrollTop);
-  }
-
-  getEditor() {
-    return atom.workspace.getActiveTextEditor();
   }
 
   getPath() {

--- a/lib/project-view.js
+++ b/lib/project-view.js
@@ -22,8 +22,9 @@ export default class ProjectView extends SymbolsView {
     if (this.panel.isVisible()) {
       this.cancel();
     } else {
+      let selectedText = this.getSelectedText();
       this.populate();
-      this.attach();
+      this.attach({query: selectedText});
     }
   }
 

--- a/lib/symbols-view.js
+++ b/lib/symbols-view.js
@@ -182,10 +182,16 @@ export default class SymbolsView {
     }
   }
 
-  attach() {
+  attach(props) {
     this.previouslyFocusedElement = document.activeElement;
     this.panel.show();
-    this.selectListView.reset();
+
+    // Reset the query if not provided
+    if (!props.query) {
+      this.selectListView.reset();
+    }
+
+    this.selectListView.update(props);
     this.selectListView.focus();
   }
 
@@ -212,5 +218,29 @@ export default class SymbolsView {
     }
 
     return undefined;
+  }
+
+  getEditor() {
+    return atom.workspace.getActiveTextEditor();
+  }
+
+  /*
+  * get the currently selected text provided there is only one selection
+  * and if the selection is not multi-line
+  */
+  getSelectedText() {
+    const editor = this.getEditor();
+    var selectedBufferRanges = editor.getSelectedBufferRanges();
+
+    var selectedText = "";
+    if (selectedBufferRanges.length == 1) {
+      selectedText = editor.getTextInBufferRange(selectedBufferRanges[0]);
+
+      if (selectedText.split("\n").length > 1) {
+        selectedText = "";
+      }
+    }
+
+    return selectedText;
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "async": "^0.2.6",
-    "atom-select-list": "^0.1.0",
+    "atom-select-list": "^0.2.0",
     "ctags": "^3.0.0",
     "fs-plus": "^3.0.0",
     "fuzzaldrin": "^2.1.0",


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
Filter symbols based on selected text. This is pretty handy feature to avoid doing ctrl-c -> ctrl-r -> ctrl-v.
If there are multiple selections or multi-line selections, we ignore the selection and fallback to the default of expecting user input.
### Alternate Designs
N/A

### Benefits
Avoids the unnecessary overhead of having to do ctrl-c -> ctrl-r -> ctrl-v. Maintains consistency in the way searches are done. For example, the standard search bar (ctrl + f) exhibits this behavior.

### Possible Drawbacks
None that I see.

### Applicable Issues
None that I see
