### PR TITLE
Wait for save to complete in tests

### DIFF
--- a/spec/symbols-view-spec.js
+++ b/spec/symbols-view-spec.js
@@ -67,7 +67,7 @@ describe('SymbolsView', () => {
       expect(symbolsView.generateTags).not.toHaveBeenCalled();
       await symbolsView.cancel();
 
-      editor.save();
+      await editor.save();
       atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
       await conditionPromise(() => symbolsView.element.querySelectorAll('li').length > 0);
       expect(symbolsView.selectListView.refs.loadingMessage).toBeUndefined();
@@ -397,7 +397,7 @@ describe('SymbolsView', () => {
       await atom.packages.activatePackage('language-javascript');
       await atom.workspace.open('sample.javascript');
       atom.workspace.getActiveTextEditor().setText('var test = function() {}');
-      atom.workspace.getActiveTextEditor().save();
+      await atom.workspace.getActiveTextEditor().save();
       atom.commands.dispatch(getEditorView(), 'symbols-view:toggle-file-symbols');
       await activationPromise;
 


### PR DESCRIPTION
The `TextBuffer.save` method is going to become async in atom/atom#14435; instead of doing a synchronous write, it will initiate an asynchronous write and return a promise when the write completes. This shouldn't affect the user-facing functionality of many packages; but several packages may have test failures.

This PR updates the two tests in `symbols-view` that broke due to this change, so that they work regardless of whether save is synchronous or asynchronous.