### PR TITLE
Added ColdFusion/CFML language support

### DIFF
--- a/lib/ctags-config
+++ b/lib/ctags-config
@@ -16,6 +16,38 @@
 --regex-CoffeeScript=/^[ \t]*xit[ \t]'([^']+)'[ \t]*,[ \t]+[-=]>/disabled: \1/f,function/
 --regex-CoffeeScript=/^[ \t]*class[ \t]*([a-zA-Z$_\.0-9]+)[ \t]*/\1/f,function/
 
+--langdef=ColdFusion
+--langmap=ColdFusion:.cfc
+--langmap=ColdFusion:+.cfm
+--langmap=ColdFusion:+.cfml
+--regex-ColdFusion=/(,|(;|^)[ \t]*(var|([A-Za-z_$][A-Za-z0-9_$.]*\.)*))[ \t]*([A-Za-z0-9_$]+)[ \t]*=[ \t]*function[ \t]*\(/\5/,function/
+--regex-ColdFusion=/function[ \t]+([A-Za-z0-9_$]+)[ \t]*\([^)]*\)/\1/,function/
+--regex-ColdFusion=/cffunction[ \t]+([A-Za-z0-9_$]+)[ \t]*\([^)]*\)/\1/,cffunction/
+--regex-ColdFusion=/(,|^|\*\/)[ \t]*([A-Za-z_$][A-Za-z0-9_$]+)[ \t]*:[ \t]*function[ \t]*\(/\2/,function/
+--regex-ColdFusion=/(,|^|\*\/)[ \t]*(static[ \t]+)?(while|if|for|function|switch|with|([A-Za-z_$][A-Za-z0-9_$]+))[ \t]*\(.*\)[ \t]*\{/\2\4/,function/
+--regex-ColdFusion=/(,|^|\*\/)[ \t]*get[ \t]+([A-Za-z_$][A-Za-z0-9_$]+)[ \t]*\([ \t]*\)[ \t]*\{/get \2/,function/
+--regex-ColdFusion=/(,|^|\*\/)[ \t]*set[ \t]+([A-Za-z_$][A-Za-z0-9_$]+)[ \t]*\([ \t]*([A-Za-z_$][A-Za-z0-9_$]+)?[ \t]*\)[ \t]*\{/set \2/,function/
+--regex-ColdFusion=/(,|^|\*\/)[ \t]*async[ \t]+([A-Za-z_$][A-Za-z0-9_$]+)[ \t]*\([ \t]*([A-Za-z_$].+)?[ \t]*\)[ \t]*\{/\2/,function/
+--regex-ColdFusion=/component[ \t]+([A-Za-z0-9._$]+)[ \t]*/\1/c,component/
+--regex-ColdFusion=/^[ \t]*given[ \t]"(.+)"[ \t]*,[ \t]+[-=]>/\1/f,function/
+--regex-ColdFusion=/^[ \t]*given[ \t]'(.+)'[ \t]*,[ \t]+[-=]>/\1/f,function/
+--regex-ColdFusion=/^[ \t]*story[ \t]"(.+)"[ \t]*,[ \t]+[-=]>/\1/f,function/
+--regex-ColdFusion=/^[ \t]*story[ \t]"(.+)"[ \t]*,[ \t]+[-=]>/\1/f,function/
+--regex-ColdFusion=/^[ \t]*feature[ \t]'(.+)'[ \t]*,[ \t]+[-=]>/\1/f,function/
+--regex-ColdFusion=/^[ \t]*feature[ \t]'(.+)'[ \t]*,[ \t]+[-=]>/\1/f,function/
+--regex-ColdFusion=/^[ \t]*when[ \t]"(.+)"[ \t]*,[ \t]+[-=]>/\1/f,function/
+--regex-ColdFusion=/^[ \t]*when[ \t]'(.+)'[ \t]*,[ \t]+[-=]>/\1/f,function/
+--regex-ColdFusion=/^[ \t]*then[ \t]"(.+)"[ \t]*,[ \t]+[-=]>/\1/f,function/
+--regex-ColdFusion=/^[ \t]*then[ \t]'(.+)'[ \t]*,[ \t]+[-=]>/\1/f,function/
+--regex-ColdFusion=/^[ \t]*describe[ \t]"(.+)"[ \t]*,[ \t]+[-=]>/\1/f,function/
+--regex-ColdFusion=/^[ \t]*describe[ \t]'(.+)'[ \t]*,[ \t]+[-=]>/\1/f,function/
+--regex-ColdFusion=/^[ \t]*it[ \t]"([^"]+)"[ \t]*,[ \t]+[-=]>/\1/f,function/
+--regex-ColdFusion=/^[ \t]*it[ \t]'([^']+)'[ \t]*,[ \t]+[-=]>/\1/f,function/
+--regex-ColdFusion=/^[ \t]*xdescribe[ \t]"(.+)"[ \t]*,[ \t]+[-=]>/disabled\: \1/f,function/
+--regex-ColdFusion=/^[ \t]*xdescribe[ \t]'(.+)'[ \t]*,[ \t]+[-=]>/disabled: \1/f,function/
+--regex-ColdFusion=/^[ \t]*xit[ \t]"([^"]+)"[ \t]*,[ \t]+[-=]>/disabled: \1/f,function/
+--regex-ColdFusion=/^[ \t]*xit[ \t]'([^']+)'[ \t]*,[ \t]+[-=]>/disabled: \1/f,function/
+
 --langdef=Css
 --langmap=Css:.css
 --langmap=Css:+.less

--- a/lib/tag-generator.js
+++ b/lib/tag-generator.js
@@ -43,34 +43,37 @@ export default class TagGenerator {
     }
 
     switch (this.scopeName) {
-      case 'source.c':        return 'C';
-      case 'source.cpp':      return 'C++';
-      case 'source.clojure':  return 'Lisp';
-      case 'source.capnp':    return 'Capnp';
-      case 'source.coffee':   return 'CoffeeScript';
-      case 'source.css':      return 'Css';
-      case 'source.css.less': return 'Css';
-      case 'source.css.scss': return 'Css';
-      case 'source.elixir':   return 'Elixir';
-      case 'source.fountain': return 'Fountain';
-      case 'source.gfm':      return 'Markdown';
-      case 'source.go':       return 'Go';
-      case 'source.java':     return 'Java';
-      case 'source.js':       return 'JavaScript';
-      case 'source.js.jsx':   return 'JavaScript';
-      case 'source.jsx':      return 'JavaScript';
-      case 'source.json':     return 'Json';
-      case 'source.julia':    return 'Julia';
-      case 'source.makefile': return 'Make';
-      case 'source.objc':     return 'C';
-      case 'source.objcpp':   return 'C++';
-      case 'source.python':   return 'Python';
-      case 'source.ruby':     return 'Ruby';
-      case 'source.sass':     return 'Sass';
-      case 'source.yaml':     return 'Yaml';
-      case 'text.html':       return 'Html';
-      case 'text.html.php':   return 'Php';
-      case 'text.tex.latex':  return 'Latex';
+      case 'source.c':                 return 'C';
+      case 'source.cpp':               return 'C++';
+      case 'source.clojure':           return 'Lisp';
+      case 'source.capnp':             return 'Capnp';
+      case 'source.cfscript':          return 'ColdFusion';
+      case 'source.cfscript.embedded': return 'ColdFusion';
+      case 'source.coffee':            return 'CoffeeScript';
+      case 'source.css':               return 'Css';
+      case 'source.css.less':          return 'Css';
+      case 'source.css.scss':          return 'Css';
+      case 'source.elixir':            return 'Elixir';
+      case 'source.fountain':          return 'Fountain';
+      case 'source.gfm':               return 'Markdown';
+      case 'source.go':                return 'Go';
+      case 'source.java':              return 'Java';
+      case 'source.js':                return 'JavaScript';
+      case 'source.js.jsx':            return 'JavaScript';
+      case 'source.jsx':               return 'JavaScript';
+      case 'source.json':              return 'Json';
+      case 'source.julia':             return 'Julia';
+      case 'source.makefile':          return 'Make';
+      case 'source.objc':              return 'C';
+      case 'source.objcpp':            return 'C++';
+      case 'source.python':            return 'Python';
+      case 'source.ruby':              return 'Ruby';
+      case 'source.sass':              return 'Sass';
+      case 'source.yaml':              return 'Yaml';
+      case 'text.html':                return 'Html';
+      case 'text.html.php':            return 'Php';
+      case 'text.tex.latex':           return 'Latex';
+      case 'text.html.cfml':           return 'ColdFusion';
     }
     return undefined;
   }


### PR DESCRIPTION
### Description of the Change

Added support for the modern ColdFusion and CFML language scripting constructs. I have also added support for BDD (Behavior Driven Development) constructs using the TestBox framework  for modern CFML script testing.

### Alternate Designs

Symbols view for the ColdFusion/CFML language was non-existent, therefore I decided to do the pull request to support it.  CFML is very similar to Java and JavaScript and provides almost 90% compatibility in language constructs as a modern JVM language.  As you will see from the pull request, the changes are trivial.

### Benefits

The entire ColdFusion and CFML eco-system will now be able to use Atom for symbols lookup instead of relying on Sublime.

### Possible Drawbacks

None that we can see.

### Applicable Issues

None that we can see.
