### PR TITLE
Fix ctags executable path resolution to support .asar+snapshots in Atom

### DIFF
--- a/lib/tag-generator.js
+++ b/lib/tag-generator.js
@@ -12,16 +12,14 @@ export default class TagGenerator {
 
   getPackageRoot() {
     const {resourcePath} = atom.getLoadSettings();
-    const currentFileWasRequiredFromSnapshot = !fs.isAbsolute(__dirname)
-    if (currentFileWasRequiredFromSnapshot) {
-      return path.join(resourcePath, 'node_modules', 'symbols-view');
+    const currentFileWasRequiredFromSnapshot = !fs.isAbsolute(__dirname);
+    const packageRoot = currentFileWasRequiredFromSnapshot
+      ? path.join(resourcePath, 'node_modules', 'symbols-view')
+      : path.resolve(__dirname, '..');
+
+    if (path.extname(resourcePath) === '.asar' && packageRoot.indexOf(resourcePath) === 0) {
+      return path.join(`${resourcePath}.unpacked`, 'node_modules', 'symbols-view');
     } else {
-      const packageRoot = path.resolve(__dirname, '..');
-      if (path.extname(resourcePath) === '.asar') {
-        if (packageRoot.indexOf(resourcePath) === 0) {
-          return path.join(`${resourcePath}.unpacked`, 'node_modules', 'symbols-view');
-        }
-      }
       return packageRoot;
     }
   }


### PR DESCRIPTION
Refs: https://github.com/atom/atom/pull/14682.

This pull-request changes symbols-view to allow it to correctly detect the `ctags` binary when Atom is bundled with both snapshots and .asar archives. This entails detecting whether the file was snapshotted or not: if so, we need to use `resourcePath` to resolve the package root path, otherwise we can simply traverse the directory tree upward.

Once we know what the absolute path of the package is, we need to detect whether Atom used `.asar` archives or not. If so, we need to search for `ctags` in the `.unpacked` folder where non-source files are stored during the creation of the .asar archive.

/cc: @iolsen 