### PR TITLE
Add support for top-level Jasmine functions in JavaScript

### DIFF
--- a/lib/ctags-config
+++ b/lib/ctags-config
@@ -130,6 +130,18 @@
 --regex-JavaScript=/(,|^|\*\/)[ \t]*set[ \t]+([A-Za-z_$][A-Za-z0-9_$]+)[ \t]*\([ \t]*([A-Za-z_$][A-Za-z0-9_$]+)?[ \t]*\)[ \t]*\{/set \2/,function/
 --regex-JavaScript=/(,|^|\*\/)[ \t]*async[ \t]+([A-Za-z_$][A-Za-z0-9_$]+)[ \t]*\([ \t]*([A-Za-z_$].+)?[ \t]*\)[ \t]*\{/\2/,function/
 --regex-JavaScript=/class[ \t]+([A-Za-z0-9._$]+)[ \t]*/\1/c,class/
+--regex-JavaScript=/^[ \t]*describe\("([^"]+)"[ \t]*,/\1/f,function/
+--regex-JavaScript=/^[ \t]*describe\('([^']+)'[ \t]*,/\1/f,function/
+--regex-JavaScript=/^[ \t]*it\("([^"]+)"[ \t]*,/\1/f,function/
+--regex-JavaScript=/^[ \t]*it\('([^']+)'[ \t]*,/\1/f,function/
+--regex-JavaScript=/^[ \t]*f+describe\('([^']+)'[ \t]*,/focused: \1/f,function/
+--regex-JavaScript=/^[ \t]*f+describe\("([^"]+)"[ \t]*,/focused: \1/f,function/
+--regex-JavaScript=/^[ \t]*f+it\('([^']+)'[ \t]*,/focused: \1/f,function/
+--regex-JavaScript=/^[ \t]*f+it\("([^"]+)"[ \t]*,/focused: \1/f,function/
+--regex-JavaScript=/^[ \t]*xdescribe\('([^']+)'[ \t]*,/disabled: \1/f,function/
+--regex-JavaScript=/^[ \t]*xdescribe\("([^"]+)"[ \t]*,/disabled: \1/f,function/
+--regex-JavaScript=/^[ \t]*xit\('([^']+)'[ \t]*,/disabled: \1/f,function/
+--regex-JavaScript=/^[ \t]*xit\("([^"]+)"[ \t]*,/disabled: \1/f,function/
 
 --langdef=haxe
 --langmap=haxe:.hx


### PR DESCRIPTION
We already support [Jasmine functions for CoffeeScript](https://github.com/atom/symbols-view/blob/7ea798df72249393db274ee25f9a541aea707c32/lib/ctags-config#L5-L16). With the changes in this pull request, we bring that same support to JavaScript.

Specifically, symbols-view will identify the following items as functions:

- `describe` blocks
- `it` blocks
- focused `it` blocks (e.g., `fit`, `ffit`, `fffit`, etc.)
- focused `describe` blocks (e.g., `fdescribe`, `ffdescribe`, `fffdescribe`, etc.)
- disabled `it` blocks (i.e., `xit`)
- disabled `describe` blocks (i.e., `xdescribe`)

### Demo

We can try this out inside symbol-views very own specs. (So meta.) Let's start by editing [`spec/symbols-view-spec.js`](https://github.com/atom/symbols-view/blob/007de32abd369144c5b920c5aa51a4eff08a4284/spec/symbols-view-spec.js) in Atom:

![screenshot](https://user-images.githubusercontent.com/2988/29982563-42f1a4ac-8f20-11e7-97ab-f21396a9c3bd.png)

**Before** the changes in this PR, the symbols view only identifies a single function:

![screenshot](https://user-images.githubusercontent.com/2988/29982617-7c6933d0-8f20-11e7-9e62-3491daa3ffb6.png)

**After** the changes in this PR, the symbols view kindly identifies Jasmine components:

![screenshot](https://user-images.githubusercontent.com/2988/29982655-9bc2f89c-8f20-11e7-89b5-31c30bf7987f.png)



