### PR TITLE
Remove a redundant caret in the regex in symbols-view.js

### DIFF
--- a/lib/symbols-view.js
+++ b/lib/symbols-view.js
@@ -194,7 +194,7 @@ export default class SymbolsView {
     if (!tag || !tag.pattern) {
       return undefined;
     }
-    const pattern = tag.pattern.replace(/(^^\/\^)|(\$\/$)/g, '').trim();
+    const pattern = tag.pattern.replace(/(^\/\^)|(\$\/$)/g, '').trim();
 
     if (!pattern) {
       return undefined;


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
Remove a double caret from a regex in `symbols-view.js`. To the best of my understanding, this just matches the start of the string twice, which is a no-op.

### Benefits

Cleanup.

### Possible Drawbacks

None, unless this double caret holds some secret meaning I don't know about. 😉
