### PR TITLE
If present, use tag line number instead of search pattern.

### DIFF
--- a/lib/symbols-view.js
+++ b/lib/symbols-view.js
@@ -190,8 +190,16 @@ export default class SymbolsView {
   }
 
   getTagLine(tag) {
+    if (!tag) {
+      return undefined;
+    }
+
+    if (tag.lineNumber) {
+      return new Point(tag.lineNumber - 1, 0);
+    }
+
     // Remove leading /^ and trailing $/
-    if (!tag || !tag.pattern) {
+    if (!tag.pattern) {
       return undefined;
     }
     const pattern = tag.pattern.replace(/(^^\/\^)|(\$\/$)/g, '').trim();

--- a/spec/fixtures/c/sample.c
+++ b/spec/fixtures/c/sample.c
@@ -1,0 +1,6 @@
+#define UNUSED(x) (void)(x)
+
+static void f(int x)
+{
+  UNUSED(x);
+}

--- a/spec/fixtures/c/tags
+++ b/spec/fixtures/c/tags
@@ -1,0 +1,8 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Exuberant Ctags	//
+!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
+!_TAG_PROGRAM_VERSION	5.8	//
+UNUSED	.\sample.c	1;"	d	file:
+f	.\sample.c	/^static void f(int x)$/;"	f	file:

--- a/spec/fixtures/c/tags
+++ b/spec/fixtures/c/tags
@@ -3,6 +3,6 @@
 !_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
 !_TAG_PROGRAM_NAME	Exuberant Ctags	//
 !_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
-!_TAG_PROGRAM_VERSION	5.8	//
-UNUSED	.\sample.c	1;"	d	file:
-f	.\sample.c	/^static void f(int x)$/;"	f	file:
+!_TAG_PROGRAM_VERSION	5.9~svn20110310	//
+UNUSED	sample.c	1;"	d	file:
+f	sample.c	/^static void f(int x)$/;"	f	file:

--- a/spec/symbols-view-spec.js
+++ b/spec/symbols-view-spec.js
@@ -170,6 +170,22 @@ describe('SymbolsView', () => {
       expect(editor.getCursorBufferPosition()).toEqual([2, 0]);
     });
 
+    it('correctly moves the cursor to the declaration of a C preprocessor macro', async () => {
+      atom.project.setPaths([temp.mkdirSync('atom-symbols-view-c-')]);
+      fs.copySync(path.join(__dirname, 'fixtures', 'c'), atom.project.getPaths()[0]);
+
+      await atom.packages.activatePackage('language-c');
+      await atom.workspace.open('sample.c');
+
+      editor = atom.workspace.getActiveTextEditor();
+      editor.setCursorBufferPosition([4, 4]);
+      spyOn(SymbolsView.prototype, 'moveToPosition').andCallThrough();
+      atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
+
+      await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
+      expect(editor.getCursorBufferPosition()).toEqual([0, 0]);
+    });
+
     it('displays matches when more than one exists and opens the selected match', async () => {
       await atom.workspace.open(directory.resolve('tagged.js'));
       editor = atom.workspace.getActiveTextEditor();


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
Line numbers are emmited by ctags, by default, in some cases. This is true for C preprocessor macros, for example. So properly handle them.

The user can request not to emit them (The `--excmd` argument to ctags, and short forms of it) but it's best for Atom to handle this correctly since this is part of the [documented syntax of ctags](http://ctags.sourceforge.net/ctags.html#TAG%20FILE%20FORMAT).

Original by: @raphinesse (PR #187). This is an updated version of that PR to ES6 from CoffeeScript + Minor Changes. Hope you don't mind 😉.

### Benefits

symbols-view will properly work with tags files that contain line number references. For example references to C/C++ macros.

Supersedes and closes https://github.com/atom/symbols-view/pull/187