### PR TITLE
Add additional keymaps for {go-to,return-from}-declaration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ If your project has a `tags`/`.tags`/`TAGS`/`.TAGS` file at the root then follow
 |-------|-----------|------------------|-----------------|--------------------|
 |`symbols-view:toggle-file-symbols`|Show all symbols in current file|<kbd>ctrl-r</kbd>|<kbd>cmd-r</kbd>|<kbd>ctrl-r</kbd>|
 |`symbols-view:toggle-project-symbols`|Show all symbols in the project|<kbd>ctrl-shift-r</kbd>|<kbd>cmd-shift-r</kbd>|<kbd>ctrl-shift-r</kbd>|
-|`symbols-view:go-to-declaration`|Jump to the symbol under the cursor|<kbd>ctrl-alt-down</kbd>|<kbd>cmd-alt-down</kbd>||
-|`symbols-view:return-from-declaration`|Return from the jump|<kbd>ctrl-alt-up</kbd>|<kbd>cmd-alt-up</kbd>||
+|`symbols-view:go-to-declaration`|Jump to the symbol under the cursor|<kbd>ctrl-alt-down</kbd><br><kbd>F12</kbd>|<kbd>cmd-alt-down</kbd><br><kbd>F12</kbd>|<kbd>F12</kbd>|
+|`symbols-view:return-from-declaration`|Return from the jump|<kbd>ctrl-alt-up</kbd><br><kbd>ctrl-F12</kbd>|<kbd>cmd-alt-up</kbd><br><kbd>cmd-F12</kbd>|<kbd>ctrl-F12</kbd>|
 
 This package uses [ctags](http://ctags.sourceforge.net).
 

--- a/keymaps/symbols-view.cson
+++ b/keymaps/symbols-view.cson
@@ -1,15 +1,21 @@
 '.platform-darwin atom-text-editor':
   'cmd-r': 'symbols-view:toggle-file-symbols'
   'cmd-alt-down': 'symbols-view:go-to-declaration'
+  'f12': 'symbols-view:go-to-declaration'
   'cmd-alt-up': 'symbols-view:return-from-declaration'
+  'cmd-f12': 'symbols-view:return-from-declaration'
 
 '.platform-win32 atom-text-editor':
   'ctrl-r': 'symbols-view:toggle-file-symbols'
+  'f12': 'symbols-view:go-to-declaration'
+  'ctrl-f12': 'symbols-view:return-from-declaration'
 
 '.platform-linux atom-text-editor':
   'ctrl-r': 'symbols-view:toggle-file-symbols'
   'ctrl-alt-down': 'symbols-view:go-to-declaration'
+  'f12': 'symbols-view:go-to-declaration'
   'ctrl-alt-up': 'symbols-view:return-from-declaration'
+  'ctrl-f12': 'symbols-view:return-from-declaration'
 
 '.platform-darwin':
   'cmd-shift-r': 'symbols-view:toggle-project-symbols'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
Add additional keymaps for `{go-to,return-from}-declaration`.

The existing keymaps don't work in Linux in some desktop environments that bind the existing keymap for desktop switching. And Windows doesn't have any keymap at all.

F12 is already used by Visual Studio, Visual Studio Code & Sublime Text 3, to the best of my knowledge. ctrl-F12 is something I made up...

### Alternate Designs

Any other keymap is a possibility. It's a matter of taste. And someone will have to make the decision what are the right default keymaps for this. This is just a suggestion.

I left the existing keymaps in place.

### Benefits

We will have a working default keymaps for `go-to-declaration` & `return-from-declaration`. Currently the Linux keymap doesn't always work and Windows doesn't have any ☹️.

### Possible Drawbacks

Keymaps are a matter of taste. Not everyone might like the keymaps I choose here.

### Applicable Issues

Mentioned in #159
