### PR TITLE
Support prefix regex patterns in tags files

### DIFF
--- a/lib/symbols-view.js
+++ b/lib/symbols-view.js
@@ -194,7 +194,8 @@ export default class SymbolsView {
     if (!tag || !tag.pattern) {
       return undefined;
     }
-    const pattern = tag.pattern.replace(/(^\/\^)|(\$\/$)/g, '').trim();
+    const pattern = tag.pattern.replace(/(^\/\^)|(\$?\/$)/g, '').trim();
+    const isPrefixPattern = tag.pattern[tag.pattern.length-2] !== '$';
 
     if (!pattern) {
       return undefined;
@@ -206,8 +207,14 @@ export default class SymbolsView {
     const iterable = fs.readFileSync(file, 'utf8').split('\n');
     for (let index = 0; index < iterable.length; index++) {
       let line = iterable[index];
-      if (pattern === line.trim()) {
-        return new Point(index, 0);
+      if (isPrefixPattern) {
+        if (line.trim().startsWith(pattern)) {
+          return new Point(index, 0);
+        }
+      } else {
+        if (pattern === line.trim()) {
+          return new Point(index, 0);
+        }
       }
     }
 

--- a/spec/fixtures/c/pattern/hello.c
+++ b/spec/fixtures/c/pattern/hello.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+#define MESSAGE "Hello, World!"
+
+int main(void) {
+    printf("%s\n", MESSAGE);
+    return 0;
+}

--- a/spec/fixtures/c/pattern/tags
+++ b/spec/fixtures/c/pattern/tags
@@ -1,0 +1,8 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Exuberant Ctags	//
+!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
+!_TAG_PROGRAM_VERSION	5.9~svn20110310	//
+MESSAGE	hello.c	/^#define MESSAGE /;"	d	file:
+main	hello.c	/^int main(void) {$/;"	f

--- a/spec/symbols-view-spec.js
+++ b/spec/symbols-view-spec.js
@@ -279,6 +279,19 @@ describe('SymbolsView', () => {
       expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([31, 0]);
     });
 
+    it('handles jumping to C macros for pattern only tags file', async () => {
+      atom.project.setPaths([temp.mkdirSync('atom-symbols-view-c-pattern-')]);
+      fs.copySync(path.join(__dirname, 'fixtures', 'c', 'pattern'), atom.project.getPaths()[0]);
+      await atom.packages.activatePackage('language-c');
+      await atom.workspace.open('hello.c');
+      spyOn(SymbolsView.prototype, 'moveToPosition').andCallThrough();
+      atom.workspace.getActiveTextEditor().setCursorBufferPosition([5, 19]);
+      atom.commands.dispatch(getEditorView(), 'symbols-view:go-to-declaration');
+
+      await conditionPromise(() => SymbolsView.prototype.moveToPosition.callCount === 1);
+      expect(atom.workspace.getActiveTextEditor().getCursorBufferPosition()).toEqual([2, 0]);
+    });
+
     describe('return from declaration', () => {
       it("doesn't do anything when no go-to have been triggered", async () => {
         await atom.workspace.open(directory.resolve('tagged.js'));


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
Out of desperation due to https://github.com/atom/symbols-view/pull/229, I tried to use `ctags -N`. But ctags than outputs prefix regex patterns for the macros instead of line numbers, which symbols-view also doesn't handle.

### Alternate Designs
In reality, those are really vi regex patterns. A truly proper implementation will try to match them as regex, possibly transforming vi regex constructs to JavaScript ones. As another note, it is also possible to request backwards search patterns via `ctags -B` which `symbols-view` also won't handle but I don't think many people really do that...

### Benefits
prefix patterns in ctags will be recognized and used correctly.

### Possible Drawbacks
Additional Complexity. Bugs?
