### PR TITLE
Don't watch editors more than once if they're re-added to the workspace

### DIFF
--- a/lib/file-view.js
+++ b/lib/file-view.js
@@ -9,8 +9,11 @@ export default class FileView extends SymbolsView {
   constructor(stack) {
     super(stack);
     this.cachedTags = {};
+    this.watchedEditors = new WeakSet();
 
     this.editorsSubscription = atom.workspace.observeTextEditors(editor => {
+      if (this.watchedEditors.has(editor)) return;
+
       const removeFromCache = () => {
         delete this.cachedTags[editor.getPath()];
       };
@@ -21,8 +24,11 @@ export default class FileView extends SymbolsView {
       editorSubscriptions.add(editor.getBuffer().onDidReload(removeFromCache));
       editorSubscriptions.add(editor.getBuffer().onDidDestroy(removeFromCache));
       editor.onDidDestroy(() => {
+        this.watchedEditors.delete(editor);
         editorSubscriptions.dispose();
       });
+
+      this.watchedEditors.add(editor);
     });
   }
 


### PR DESCRIPTION
This will prevent this package from providing its functionality to editors more than once in case they get added to the workspace, then removed from it and finally added back.

/cc: @nathansobo @jasonrudolph