### PR TITLE
Update keymaps

### DIFF
--- a/keymaps/symbols-view.cson
+++ b/keymaps/symbols-view.cson
@@ -5,6 +5,8 @@
 
 '.platform-win32 atom-text-editor':
   'ctrl-r': 'symbols-view:toggle-file-symbols'
+  'ctrl-alt-down': 'symbols-view:go-to-declaration'
+  'ctrl-alt-up': 'symbols-view:return-from-declaration'
 
 '.platform-linux atom-text-editor':
   'ctrl-r': 'symbols-view:toggle-file-symbols'


### PR DESCRIPTION
- add 'ctrl-alt-up', 'ctrl-alt-down' in win32

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->
In the manual, linux and window have same function. but keymap`s win32 do not have code.
### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
