### PR TITLE
Add puppet syntax support

### DIFF
--- a/lib/tag-reader.js
+++ b/lib/tag-reader.js
@@ -60,13 +60,13 @@ export default {
       editor.scanInBufferRange(wordRegExp, cursor.getCurrentLineBufferRange(), ({range, match}) => {
         if (range.containsPoint(cursorPosition)) {
           symbol = match[0];
-          if (rubyScopes.length && symbol.indexOf(':') > -1) {0
+          if (rubyScopes.length && symbol.indexOf(':') > -1) {
             const cursorWithinSymbol = cursorPosition.column - range.start.column;
             // Add fully-qualified ruby constant up until the cursor position
             addSymbol(wordAtCursor(symbol, cursorWithinSymbol, ':', true));
             // Additionally, also look up the bare word under cursor
             addSymbol(wordAtCursor(symbol, cursorWithinSymbol, ':'));
-          } else if (puppetScopes.length && symbol.indexOf('::') > -1) {0
+          } else if (puppetScopes.length && symbol.indexOf('::') > -1) {
             const cursorWithinSymbol = cursorPosition.column - range.start.column;
             // Add fully-qualified ruby constant up until the cursor position
             addSymbol(wordAtCursor(symbol, cursorWithinSymbol, '::', true));

--- a/lib/tag-reader.js
+++ b/lib/tag-reader.js
@@ -34,6 +34,7 @@ export default {
       const cursorPosition = cursor.getBufferPosition();
       const scope = cursor.getScopeDescriptor();
       const rubyScopes = scope.getScopesArray().filter(s => /^source\.ruby($|\.)/.test(s));
+      const puppetScopes = scope.getScopesArray().filter(s => /^source\.puppet($|\.)/.test(s));
 
       const wordRegExp = rubyScopes.length ?
         (nonWordCharacters = atom.config.get('editor.nonWordCharacters', {scope}),
@@ -59,12 +60,20 @@ export default {
       editor.scanInBufferRange(wordRegExp, cursor.getCurrentLineBufferRange(), ({range, match}) => {
         if (range.containsPoint(cursorPosition)) {
           symbol = match[0];
-          if (rubyScopes.length && symbol.indexOf(':') > -1) {
+          if (rubyScopes.length && symbol.indexOf(':') > -1) {0
             const cursorWithinSymbol = cursorPosition.column - range.start.column;
             // Add fully-qualified ruby constant up until the cursor position
             addSymbol(wordAtCursor(symbol, cursorWithinSymbol, ':', true));
             // Additionally, also look up the bare word under cursor
             addSymbol(wordAtCursor(symbol, cursorWithinSymbol, ':'));
+          } else if (puppetScopes.length && symbol.indexOf('::') > -1) {0
+            const cursorWithinSymbol = cursorPosition.column - range.start.column;
+            // Add fully-qualified ruby constant up until the cursor position
+            addSymbol(wordAtCursor(symbol, cursorWithinSymbol, '::', true));
+            // Additionally, also look up the bare word under cursor
+            addSymbol(wordAtCursor(symbol, cursorWithinSymbol, '::'));
+                                                              
+                                                              
           } else {
             addSymbol(symbol);
           }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

currently symbols-view has a special case for ruby notation (':'-separated) however it fails with Puppet notation ('::') - ruby's solution has been extended to provide puppet support

### Alternate Designs

Alternatively there should be a map of language and word separators that could be extended by user. but implementation of such feature is beyond my current abilities in JS

### Benefits

Puppet ctags will work as expected

### Possible Drawbacks

none

### Applicable Issues

#244